### PR TITLE
Include checkout of gep-kne/keysight on vm image

### DIFF
--- a/cloudbuild/ubuntu.pkr.hcl
+++ b/cloudbuild/ubuntu.pkr.hcl
@@ -90,8 +90,9 @@ build {
 
   provisioner "shell" {
     inline = [
-      "echo Cloning kne-internal cloud source repo...",
+      "echo Cloning internal cloud source repos...",
       "gcloud source repos clone kne-internal --project=gep-kne",
+      "gcloud source repos clone keysight --project=gep-kne",
     ]
   }
 }


### PR DESCRIPTION
This is to ensure that the base checkout of the kne_cli references the same versions as the base checkout of keysight. This should simplify the setup for our internal users. The repo can always be synced to the latest checkout on the VM instance if the user desires.