### PR TITLE
added nokia sr linux with startup config example

### DIFF
--- a/examples/srlinux/22.6.1.cfg.json
+++ b/examples/srlinux/22.6.1.cfg.json
@@ -1,0 +1,2358 @@
+{
+    "_preamble": {
+        "header": {
+            "generated-by": "SRLINUX",
+            "name": "",
+            "comment": "",
+            "created": "2022-07-19T06:42:44.320Z",
+            "release": "v22.6.1",
+            "enabled-yang-features": [
+                "srl_nokia-features:anycast-gw",
+                "srl_nokia-features:bgp-ipv6-next-hop-tunnel-resolution",
+                "srl_nokia-features:bgp-single-hop-connected-check",
+                "srl_nokia-features:bgp-unnumbered-peers",
+                "srl_nokia-features:bridged",
+                "srl_nokia-features:bt-evpn-vlan-aware-bundle-interop",
+                "srl_nokia-features:dac-link-training",
+                "srl_nokia-features:event-handler",
+                "srl_nokia-features:evpn",
+                "srl_nokia-features:evpn-advertise-arp-nd-only-with-mac-table-entry",
+                "srl_nokia-features:evpn-mh-ip-aliasing",
+                "srl_nokia-features:evpn-mh-manual-alg",
+                "srl_nokia-features:evpn-mh-pref-alg",
+                "srl_nokia-features:evpn-mh-single-active",
+                "srl_nokia-features:evpn-mh-virtual-es",
+                "srl_nokia-features:fixed",
+                "srl_nokia-features:future-22-6",
+                "srl_nokia-features:gnoi",
+                "srl_nokia-features:gribi",
+                "srl_nokia-features:ip-acl-dscp-set",
+                "srl_nokia-features:irb-interface",
+                "srl_nokia-features:l2-proxy-arp",
+                "srl_nokia-features:l2cp-transparency",
+                "srl_nokia-features:l3-proxy-arp",
+                "srl_nokia-features:l3-proxy-nd",
+                "srl_nokia-features:lacp-fallback",
+                "srl_nokia-features:lag",
+                "srl_nokia-features:mirroring",
+                "srl_nokia-features:platform-7220-d2",
+                "srl_nokia-features:ra-guard",
+                "srl_nokia-features:reload-delay",
+                "srl_nokia-features:segment-routing-adjacency-sid",
+                "srl_nokia-features:segment-routing-shared-sid",
+                "srl_nokia-features:storm-control",
+                "srl_nokia-features:trident3",
+                "srl_nokia-features:virtual-ip-discovery",
+                "srl_nokia-features:vlan-tpid",
+                "srl_nokia-features:vxlan",
+                "srl_nokia-features:warm-reboot"
+            ],
+            "checksum": "a8350fc70d45271e$b750e83d907edc87888a1566dde13e2ca16c6f13"
+        },
+        "build": {
+            "git-branch": "SRL_22_6_B1",
+            "git-tag": "v22.6.1-281-gf7b7d66598",
+            "git-sha": "f7b7d6659824da2e01fddec6fb0d3b4198e6d488"
+        },
+        "application": [
+            {
+                "name": "aaa_mgr",
+                "path": "/opt/srlinux/bin/sr_aaa_mgr",
+                "version": "2403-01-20T16:29:46.709Z"
+            },
+            {
+                "name": "acl_mgr",
+                "path": "/opt/srlinux/bin/sr_acl_mgr",
+                "version": "2403-01-20T16:27:40.709Z"
+            },
+            {
+                "name": "app_mgr",
+                "path": "/opt/srlinux/bin/sr_app_mgr",
+                "version": "2403-01-20T16:28:17.709Z"
+            },
+            {
+                "name": "arp_nd_mgr",
+                "path": "/opt/srlinux/bin/sr_arp_nd_mgr",
+                "version": "2403-01-20T16:29:39.709Z"
+            },
+            {
+                "name": "bfd_mgr",
+                "path": "/opt/srlinux/bin/sr_bfd_mgr",
+                "version": "2403-01-20T16:27:10.709Z"
+            },
+            {
+                "name": "bgp_mgr",
+                "path": "/opt/srlinux/bin/sr_bgp_mgr",
+                "version": "2403-01-20T16:29:59.709Z"
+            },
+            {
+                "name": "chassis_mgr",
+                "path": "/opt/srlinux/bin/sr_chassis_mgr",
+                "version": "2403-01-20T16:27:29.709Z"
+            },
+            {
+                "name": "dev_mgr",
+                "path": "/opt/srlinux/bin/sr_device_mgr",
+                "version": "2403-01-20T16:30:11.709Z"
+            },
+            {
+                "name": "dhcp_client_mgr",
+                "path": "/opt/srlinux/bin/sr_dhcp_client_mgr",
+                "version": "2403-01-20T16:29:12.709Z"
+            },
+            {
+                "name": "dhcp_relay_mgr",
+                "path": "/opt/srlinux/bin/sr_dhcp_relay_mgr",
+                "version": "2403-01-20T16:29:19.709Z"
+            },
+            {
+                "name": "dhcp_server_mgr",
+                "path": "/opt/srlinux/bin/sr_dhcp_server_mgr",
+                "version": "2403-01-20T16:29:05.709Z"
+            },
+            {
+                "name": "ethcfm_mgr",
+                "path": "/opt/srlinux/bin/sr_ethcfm_mgr",
+                "version": "2403-01-20T16:26:37.709Z"
+            },
+            {
+                "name": "event_mgr",
+                "path": "/opt/srlinux/bin/sr_event_mgr",
+                "version": "2403-01-20T16:26:27.709Z"
+            },
+            {
+                "name": "evpn_mgr",
+                "path": "/opt/srlinux/bin/sr_evpn_mgr",
+                "version": "2403-01-20T16:29:51.709Z"
+            },
+            {
+                "name": "fhs_mgr",
+                "path": "/opt/srlinux/bin/sr_fhs_mgr",
+                "version": "2403-01-20T16:26:42.709Z"
+            },
+            {
+                "name": "fib_mgr",
+                "path": "/opt/srlinux/bin/sr_fib_mgr",
+                "version": "2403-01-20T16:27:03.709Z"
+            },
+            {
+                "name": "gnmi_server",
+                "path": "/opt/srlinux/bin/sr_gnmi_server",
+                "version": "2403-01-20T16:28:15.709Z"
+            },
+            {
+                "name": "gribi_server",
+                "path": "/opt/srlinux/bin/sr_gribi_server",
+                "version": "2403-01-20T16:27:40.709Z"
+            },
+            {
+                "name": "idb_server",
+                "path": "/opt/srlinux/bin/sr_idb_server",
+                "version": "2403-01-20T16:25:56.709Z"
+            },
+            {
+                "name": "igmp_mgr",
+                "path": "/opt/srlinux/bin/sr_igmp_mgr",
+                "version": "2403-01-20T16:29:52.709Z"
+            },
+            {
+                "name": "isis_mgr",
+                "path": "/opt/srlinux/bin/sr_isis_mgr",
+                "version": "2403-01-20T16:29:59.709Z"
+            },
+            {
+                "name": "json_rpc",
+                "path": "/opt/srlinux/bin/sr_json_rpc",
+                "version": "2403-01-20T16:27:05.709Z"
+            },
+            {
+                "name": "l2_mac_learn_mgr",
+                "path": "/opt/srlinux/bin/sr_l2_mac_learn_mgr",
+                "version": "2403-01-20T16:27:07.709Z"
+            },
+            {
+                "name": "l2_mac_mgr",
+                "path": "/opt/srlinux/bin/sr_l2_mac_mgr",
+                "version": "2403-01-20T16:27:17.709Z"
+            },
+            {
+                "name": "l2_proxy_arp_nd_mgr",
+                "path": "/opt/srlinux/bin/sr_l2_proxy_arp_nd_mgr",
+                "version": "2403-01-20T16:29:51.709Z"
+            },
+            {
+                "name": "l2_static_mac_mgr",
+                "path": "/opt/srlinux/bin/sr_l2_static_mac_mgr",
+                "version": "2403-01-20T16:27:05.709Z"
+            },
+            {
+                "name": "label_mgr",
+                "path": "/opt/srlinux/bin/sr_label_mgr",
+                "version": "2403-01-20T16:29:10.709Z"
+            },
+            {
+                "name": "lag_mgr",
+                "path": "/opt/srlinux/bin/sr_lag_mgr",
+                "version": "2403-01-20T16:26:33.709Z"
+            },
+            {
+                "name": "ldp_mgr",
+                "path": "/opt/srlinux/bin/sr_ldp_mgr",
+                "version": "2403-01-20T16:29:51.709Z"
+            },
+            {
+                "name": "linux_mgr",
+                "path": "/opt/srlinux/bin/sr_linux_mgr",
+                "version": "2403-01-20T16:28:39.709Z"
+            },
+            {
+                "name": "dnsmasq",
+                "path": "/usr/sbin/dnsmasq",
+                "version": "2402-09-13T14:40:11.709Z"
+            },
+            {
+                "name": "sshd",
+                "path": "/usr/sbin/sshd",
+                "version": "2402-05-16T12:44:57.709Z"
+            },
+            {
+                "name": "ntpd",
+                "path": "/usr/sbin/chronyd",
+                "version": "2402-01-12T13:55:50.709Z"
+            },
+            {
+                "name": "vsftpd",
+                "path": "/usr/sbin/vsftpd",
+                "version": "2402-08-17T07:10:54.709Z"
+            },
+            {
+                "name": "snmp_server",
+                "path": "/opt/srlinux/bin/sr_snmp_server",
+                "version": "2403-01-20T16:25:51.709Z"
+            },
+            {
+                "name": "timesrv",
+                "path": "/usr/sbin/chronyd",
+                "version": "2402-01-12T13:55:50.709Z"
+            },
+            {
+                "name": "lldp_mgr",
+                "path": "/opt/srlinux/bin/sr_lldp_mgr",
+                "version": "2403-01-20T16:27:15.709Z"
+            },
+            {
+                "name": "log_mgr",
+                "path": "/opt/srlinux/bin/sr_log_mgr",
+                "version": "2403-01-20T16:26:26.709Z"
+            },
+            {
+                "name": "mcid_mgr",
+                "path": "/opt/srlinux/bin/sr_mcid_mgr",
+                "version": "2403-01-20T16:27:07.709Z"
+            },
+            {
+                "name": "mgmt_server",
+                "path": "/opt/srlinux/bin/sr_mgmt_server",
+                "version": "2403-01-20T16:30:35.709Z"
+            },
+            {
+                "name": "common",
+                "path": "n/a",
+                "version": "n/a"
+            },
+            {
+                "name": "mirror_mgr",
+                "path": "/opt/srlinux/bin/sr_mirror_mgr",
+                "version": "2403-01-20T16:26:26.709Z"
+            },
+            {
+                "name": "mpls_mgr",
+                "path": "/opt/srlinux/bin/sr_mpls_mgr",
+                "version": "2403-01-20T16:28:55.709Z"
+            },
+            {
+                "name": "net_inst_mgr",
+                "path": "/opt/srlinux/bin/sr_net_inst_mgr",
+                "version": "2403-01-20T16:26:47.709Z"
+            },
+            {
+                "name": "oam_mgr",
+                "path": "/opt/srlinux/bin/sr_oam_mgr",
+                "version": "2403-01-20T16:26:39.709Z"
+            },
+            {
+                "name": "oc_mgmt_server",
+                "path": "/opt/srlinux/bin/sr_oc_mgmt_server",
+                "version": "2403-01-20T16:30:35.709Z"
+            },
+            {
+                "name": "ospf_mgr",
+                "path": "/opt/srlinux/bin/sr_ospf_mgr",
+                "version": "2403-01-20T16:29:58.709Z"
+            },
+            {
+                "name": "p4rt_server",
+                "path": "/opt/srlinux/bin/sr_p4rt_server",
+                "version": "2403-01-20T16:27:30.709Z"
+            },
+            {
+                "name": "pim_mgr",
+                "path": "/opt/srlinux/bin/sr_pim_mgr",
+                "version": "2403-01-20T16:29:55.709Z"
+            },
+            {
+                "name": "plcy_mgr",
+                "path": "/opt/srlinux/bin/sr_plcy_mgr",
+                "version": "2403-01-20T16:29:51.709Z"
+            },
+            {
+                "name": "maint_mode_mgr",
+                "path": "n/a",
+                "version": "n/a"
+            },
+            {
+                "name": "qos_mgr",
+                "path": "/opt/srlinux/bin/sr_qos_mgr",
+                "version": "2403-01-20T16:26:55.709Z"
+            },
+            {
+                "name": "sdk_mgr",
+                "path": "/opt/srlinux/bin/sr_sdk_mgr",
+                "version": "2403-01-20T16:27:27.709Z"
+            },
+            {
+                "name": "segrt_mgr",
+                "path": "/opt/srlinux/bin/sr_segrt_mgr",
+                "version": "2403-01-20T16:29:26.709Z"
+            },
+            {
+                "name": "sflow_sample_mgr",
+                "path": "/opt/srlinux/bin/sr_sflow_sample_mgr",
+                "version": "2403-01-20T16:27:18.709Z"
+            },
+            {
+                "name": "srpolicy_mgr",
+                "path": "/opt/srlinux/bin/sr_srpolicy_mgr",
+                "version": "2403-01-20T16:29:24.709Z"
+            },
+            {
+                "name": "static_route_mgr",
+                "path": "/opt/srlinux/bin/sr_static_route_mgr",
+                "version": "2403-01-20T16:29:50.709Z"
+            },
+            {
+                "name": "supportd",
+                "path": "/opt/srlinux/bin/sr_supportd",
+                "version": "2403-01-20T16:25:57.709Z"
+            },
+            {
+                "name": "te_mgr",
+                "path": "/opt/srlinux/bin/sr_te_mgr",
+                "version": "2403-01-20T16:29:38.709Z"
+            },
+            {
+                "name": "time_mgr",
+                "path": "/opt/srlinux/bin/sr_time_mgr",
+                "version": "2403-01-20T16:28:58.709Z"
+            },
+            {
+                "name": "twamp_mgr",
+                "path": "/opt/srlinux/bin/sr_twamp_mgr",
+                "version": "2403-01-20T16:29:24.709Z"
+            },
+            {
+                "name": "vrrp_mgr",
+                "path": "/opt/srlinux/bin/sr_vrrp_mgr",
+                "version": "2403-01-20T16:29:31.709Z"
+            },
+            {
+                "name": "vxlan_mgr",
+                "path": "/opt/srlinux/bin/sr_vxlan_mgr",
+                "version": "2403-01-20T16:27:25.709Z"
+            },
+            {
+                "name": "xdp_cpm",
+                "path": "/opt/srlinux/bin/sr_xdp_cpm",
+                "version": "2403-01-20T16:26:08.709Z"
+            },
+            {
+                "name": "xdp_lc",
+                "path": "/opt/srlinux/bin/sr_xdp_lc",
+                "version": "2403-01-20T16:29:29.709Z"
+            }
+        ],
+        "yang-module": [
+            {
+                "name": "srl_nokia-aaa",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-aaa-password",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-aaa-types",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-acl",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-aggregate-routes",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-app-mgmt",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-bfd",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bgp",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bgp-evpn",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bgp-evpn-bgp-instance-mpls-bridge-table-multicast-destinations",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bgp-evpn-bgp-instance-mpls-bridge-table-statistics",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-bgp-evpn-bgp-instance-mpls-bridge-table-unicast-destinations",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-bgp-vpn",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-boot",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-duplication",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-duplication-entries",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-learning",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-learning-entries",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-limit",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table-mac-table",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table-proxy-arp-nd",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table-reserved-macs",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-bridge-table-static-mac",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-configuration",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-configuration-role",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-dhcp-server",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-dns",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-ethcfm",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-ethcfm-pm",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-event-handler",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-ftp",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-gnmi-server",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-gribi-server",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-icmp",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-if-ip",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-if-mpls",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-igmp",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-igmp-types",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-interfaces",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-bridge-table",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-bridge-table-mac-duplication-entries",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-bridge-table-mac-learning-entries",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-bridge-table-mac-table",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-bridge-table-statistics",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-ethernet-segment-association",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-ip-dhcp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-ip-dhcp-relay",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-ip-dhcp-server",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-ip-vrrp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-l2cp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-lag",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-local-mirror-destination",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-nbr",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-nbr-evpn",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-interfaces-nbr-virtual-ip-discovery",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-p4rt",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-router-adv",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-vlans",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-interfaces-vxdp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-ip-route-tables",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-isis",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-json-rpc",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-keychains",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-lacp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-ldp",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-linux",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-lldp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-lldp-types",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-load-balancing",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-logging",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-maintenance-mode",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-micro-bfd",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-mirroring",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-mld",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-mpls",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-mpls-label-management",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-mpls-route-tables",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-mpls-services-evpn-label-management",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-mtu",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-network-instance",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-network-instance-mtu",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-next-hop-groups",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-ntp",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-oam",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-openconfig",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-ospf",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-p4rt-server",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-packet-match-types",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-pim",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-platform",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-acl",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-platform-cgroup",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-chassis",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-console",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-control",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-cpu",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-datapath-resources",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-disk",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-fabric",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-platform-fan",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-lc",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-platform-memory",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-mtu",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-p4rt",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-platform-pipeline-counters",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-psu",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-qos",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-redundancy",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-platform-resource-mgmt",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-resource-monitoring",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-platform-vxdp",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-policy-forwarding",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-qos",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-qos-policers",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-ra_guard",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-rib-bgp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-routing-policy",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-segment-routing",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-sflow",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-snmp",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-sr-policies",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-ssh",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-static-routes",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-system",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-system-banner",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-system-bridge-table",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-system-bridge-table-proxy-arp",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-system-info",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-system-name",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-system-network-instance",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-system-network-instance-bgp-evpn-ethernet-segments",
+                "revision": "2022-03-31"
+            },
+            {
+                "name": "srl_nokia-system-network-instance-bgp-vpn",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-system-reboot",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-tcp-udp",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-timezone",
+                "revision": "2020-06-30"
+            },
+            {
+                "name": "srl_nokia-tls",
+                "revision": "2019-11-30"
+            },
+            {
+                "name": "srl_nokia-traffic-engineering",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-tunnel",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-tunnel-interfaces",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-tunnel-interfaces-vxlan-interface-bridge-table",
+                "revision": "2021-06-30"
+            },
+            {
+                "name": "srl_nokia-tunnel-interfaces-vxlan-interface-bridge-table-multicast-destinations",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-tunnel-interfaces-vxlan-interface-bridge-table-unicast-destinations",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-tunnel-interfaces-vxlan-interface-bridge-table-unicast-es-destination-vteps",
+                "revision": "2021-03-31"
+            },
+            {
+                "name": "srl_nokia-tunnel-tables",
+                "revision": "2021-11-30"
+            },
+            {
+                "name": "srl_nokia-twamp",
+                "revision": "2022-06-30"
+            },
+            {
+                "name": "srl_nokia-vxlan-tunnel-vtep",
+                "revision": "2021-11-30"
+            }
+        ]
+    },
+    "srl_nokia-acl:acl": {
+        "cpm-filter": {
+            "ipv4-filter": {
+                "statistics-per-entry": true,
+                "entry": [
+                    {
+                        "sequence-id": 10,
+                        "description": "Accept incoming ICMP unreachable messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "dest-unreachable",
+                                "code": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    13
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 20,
+                        "description": "Accept incoming ICMP time-exceeded messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "time-exceeded"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 30,
+                        "description": "Accept incoming ICMP parameter problem messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "param-problem"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 40,
+                        "description": "Accept incoming ICMP echo messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "echo"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 50,
+                        "description": "Accept incoming ICMP echo-reply messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "echo-reply"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 60,
+                        "description": "Accept incoming SSH when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 22
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 70,
+                        "description": "Accept incoming SSH when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 22
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 80,
+                        "description": "Accept incoming Telnet when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 23
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 90,
+                        "description": "Accept incoming Telnet when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 23
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 100,
+                        "description": "Accept incoming TACACS+ when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 49
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 110,
+                        "description": "Accept incoming TACACS+ when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 49
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 120,
+                        "description": "Accept incoming DNS response messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 53
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 130,
+                        "description": "Accept incoming DHCP messages targeted for BOOTP/DHCP client",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 68
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 140,
+                        "description": "Accept incoming TFTP read-request and write-request messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 69
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 150,
+                        "description": "Accept incoming HTTP(JSON-RPC) when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 80
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 160,
+                        "description": "Accept incoming HTTP(JSON-RPC) when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 80
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 170,
+                        "description": "Accept incoming NTP messages from servers",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 123
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 180,
+                        "description": "Accept incoming SNMP GET/GETNEXT messages from servers",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 161
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 190,
+                        "description": "Accept incoming BGP when the other router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 179
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 200,
+                        "description": "Accept incoming BGP when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 179
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 210,
+                        "description": "Accept incoming HTTPS(JSON-RPC) when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 443
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 220,
+                        "description": "Accept incoming HTTPS(JSON-RPC) when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 443
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 230,
+                        "description": "Accept incoming single-hop BFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 3784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 240,
+                        "description": "Accept incoming multi-hop BFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 4784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 250,
+                        "description": "Accept incoming uBFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 6784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 260,
+                        "description": "Accept incoming gNMI messages when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 57400
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 270,
+                        "description": "Accept incoming UDP traceroute messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "range": {
+                                    "start": 33434,
+                                    "end": 33464
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 280,
+                        "description": "Accept incoming ICMP timestamp messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "protocol": "icmp",
+                            "icmp": {
+                                "type": "timestamp"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 290,
+                        "description": "Accept incoming OSPF messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": 89
+                        }
+                    },
+                    {
+                        "sequence-id": 300,
+                        "description": "Accept incoming DHCP relay messages targeted for BOOTP/DHCP server",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 67
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 310,
+                        "description": "Accept ICMP fragment packets",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "fragment": true,
+                            "protocol": "icmp"
+                        }
+                    },
+                    {
+                        "sequence-id": 320,
+                        "description": "Accept incoming LDP packets",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "udp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 646
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 330,
+                        "description": "Accept incoming LDP packets with source-port 646",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 646
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 340,
+                        "description": "Accept incoming LDP packets with destination-port 646",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 646
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 350,
+                        "description": "Accept incoming gRIBI packets with destination-port 57401",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 57401
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 360,
+                        "description": "Accept incoming p4rt packets with destination-port 9559",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 9559
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 370,
+                        "description": "Accept incoming IGMP packets",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "protocol": "igmp"
+                        }
+                    },
+                    {
+                        "sequence-id": 380,
+                        "description": "Drop all else",
+                        "action": {
+                            "drop": {
+                                "log": true
+                            }
+                        }
+                    }
+                ]
+            },
+            "ipv6-filter": {
+                "statistics-per-entry": true,
+                "entry": [
+                    {
+                        "sequence-id": 10,
+                        "description": "Accept incoming ICMPv6 unreachable messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "dest-unreachable",
+                                "code": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 20,
+                        "description": "Accept incoming ICMPv6 packet-too-big messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "packet-too-big"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 30,
+                        "description": "Accept incoming ICMPv6 time-exceeded messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "time-exceeded"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 40,
+                        "description": "Accept incoming ICMPv6 parameter problem messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "param-problem"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 50,
+                        "description": "Accept incoming ICMPv6 echo-request messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "echo-request"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 60,
+                        "description": "Accept incoming ICMPv6 echo-reply messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "echo-reply"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 70,
+                        "description": "Accept incoming ICMPv6 router-advertisement messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "router-advertise"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 80,
+                        "description": "Accept incoming ICMPv6 neighbor-solicitation messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "neighbor-solicit"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 90,
+                        "description": "Accept incoming ICMPv6 neighbor-advertisement messages",
+                        "action": {
+                            "accept": {
+                                "rate-limit": {
+                                    "system-cpu-policer": "icmp"
+                                }
+                            }
+                        },
+                        "match": {
+                            "next-header": "icmp6",
+                            "icmp6": {
+                                "type": "neighbor-advertise"
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 100,
+                        "description": "Accept incoming SSH when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 22
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 110,
+                        "description": "Accept incoming SSH when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 22
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 120,
+                        "description": "Accept incoming Telnet when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 23
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 130,
+                        "description": "Accept incoming Telnet when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 23
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 140,
+                        "description": "Accept incoming TACACS+ when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 49
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 150,
+                        "description": "Accept incoming TACACS+ when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 49
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 160,
+                        "description": "Accept incoming DNS response messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 53
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 170,
+                        "description": "Accept incoming TFTP read-request and write-request messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 69
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 180,
+                        "description": "Accept incoming HTTP(JSON-RPC) when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 80
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 190,
+                        "description": "Accept incoming HTTP(JSON-RPC) when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 80
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 200,
+                        "description": "Accept incoming NTP messages from servers",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 123
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 210,
+                        "description": "Accept incoming SNMP GET/GETNEXT messages from servers",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 161
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 220,
+                        "description": "Accept incoming BGP when the other router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 179
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 230,
+                        "description": "Accept incoming BGP when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 179
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 240,
+                        "description": "Accept incoming HTTPS(JSON-RPC) when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 443
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 250,
+                        "description": "Accept incoming HTTPS(JSON-RPC) when this router initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "source-port": {
+                                "operator": "eq",
+                                "value": 443
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 260,
+                        "description": "Accept incoming DHCPv6 client messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 546
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 270,
+                        "description": "Accept incoming single-hop BFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 3784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 280,
+                        "description": "Accept incoming multi-hop BFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 4784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 290,
+                        "description": "Accept incoming uBFD session messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 6784
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 300,
+                        "description": "Accept incoming gNMI messages when the other host initiates the TCP connection",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 57400
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 310,
+                        "description": "Accept incoming UDP traceroute messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "range": {
+                                    "start": 33434,
+                                    "end": 33464
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 320,
+                        "description": "Accept incoming IPV6 hop-in-hop messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": 0
+                        }
+                    },
+                    {
+                        "sequence-id": 330,
+                        "description": "Accept incoming IPV6 fragment header messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": 44
+                        }
+                    },
+                    {
+                        "sequence-id": 340,
+                        "description": "Accept incoming OSPF messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": 89
+                        }
+                    },
+                    {
+                        "sequence-id": 350,
+                        "description": "Accept incoming DHCPv6 relay messages",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "udp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 547
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 360,
+                        "description": "Accept incoming gRIBI packets with destination-port 57401",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 57401
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 370,
+                        "description": "Accept incoming p4rt packets with destination-port 9559",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "tcp",
+                            "destination-port": {
+                                "operator": "eq",
+                                "value": 9559
+                            }
+                        }
+                    },
+                    {
+                        "sequence-id": 380,
+                        "description": "Accept incoming IGMP packets",
+                        "action": {
+                            "accept": {}
+                        },
+                        "match": {
+                            "next-header": "igmp"
+                        }
+                    },
+                    {
+                        "sequence-id": 390,
+                        "description": "Drop all else",
+                        "action": {
+                            "drop": {
+                                "log": true
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "policers": {
+            "system-cpu-policer": [
+                {
+                    "name": "icmp",
+                    "entry-specific": false,
+                    "peak-packet-rate": 1000,
+                    "max-packet-burst": 1000
+                }
+            ]
+        }
+    },
+    "srl_nokia-interfaces:interface": [
+        {
+            "name": "mgmt0",
+            "admin-state": "enable",
+            "subinterface": [
+                {
+                    "index": 0,
+                    "admin-state": "enable",
+                    "ipv4": {
+                        "srl_nokia-interfaces-ip-dhcp:dhcp-client": {}
+                    },
+                    "ipv6": {
+                        "srl_nokia-interfaces-ip-dhcp:dhcp-client": {}
+                    }
+                }
+            ]
+        }
+    ],
+    "srl_nokia-system:system": {
+        "srl_nokia-aaa:aaa": {
+            "authentication": {
+                "idle-timeout": 7200,
+                "authentication-method": [
+                    "local"
+                ]
+            },
+            "server-group": [
+                {
+                    "name": "local",
+                    "type": "srl_nokia-aaa-types:local"
+                }
+            ]
+        },
+        "srl_nokia-lldp:lldp": {
+            "admin-state": "enable"
+        },
+        "srl_nokia-gnmi-server:gnmi-server": {
+            "admin-state": "enable",
+            "network-instance": [
+                {
+                    "name": "mgmt",
+                    "admin-state": "enable",
+                    "tls-profile": "clab-profile"
+                }
+            ]
+        },
+        "srl_nokia-tls:tls": {
+            "server-profile": [
+                {
+                    "name": "clab-profile",
+                    "key": "$aes$bQAMyBfahHso=$U2JGqhoeA9vMvIycLQpPkae9cbDEALQd8VmsxAsvYZ3IErC2E7tT9sIXF5QsB7JwIk5u27CdcnUuN3BAxsX6UfwAVJ2OfkTnHAHnRfoU9W66BBEVW2Z4nnyIiMD3isxD7fFZbGkGovr6y25F1Ddkg4z4wwLAVDAuSKH2+hfTDmH0oWUmOG4vEg0DX2Bpaqeixqi8guIJt15tyjIFEHD8qzizONEW5rGqhy+evET4jUUNknzqL91mEHI3DkJAGd0fLPyMjmF2MpuMStl/vPBXEtNY8LjPRBf5IraSUY1DNSrxED4723rkOKjnesppTFpo0fsIPSR0ZQ9z9f9frBrYb3MQ4umF7kZs7d8HEnGzkV3rnFfWh5RmNaI2qqrl9HK4ZQE+Vj9G05dVD+Kbbrjmzs7EK2lBRnRgIbdOJwyhH0inT++A0f+rleyH1IUOXswb+ZnwQFy8ZX6hkzYI9Omd0dj+g1xPCn9EV3IxmBj1vN8cvi0vQ+talfEmfmuiZrrpMpO3orKUJIaAbNnxIjNFOIz5CZCqRDAJ64fto8afXRnlp2W/bQGIHdcguZGC3a3pZR1RZ82+igRNJcKAgoKMvkhHlX122/T8+DnvNOFiitOd1TR3fyAhq2gDWjvd313qlEWU8PGrXG9o+alk92Cpu7rQg6tEqy7mAIMbHbyKarYbWX8yW74EKkgA+5dL5tJA5hY1R9rT2IVEvH1pWh0X5JJGR+Gs8W6la38Ji4I3oMyA27fofFO0bcsQb3wyPwK0IKy6T7qdHmyPAxkJ5lpqOWWaPXpqKb3KjBBhJwgkzgEkRyIYpHutdkLmQPCm6rumWWVTEYUHt5SgiRpDcJ0kDiTQDGn6Yp/G/kvuQ8GxxY0GjoNVIRtdubqm7FQkrmyZxujCFQIm86BgvRMuEniY93Ez5lBm39IgXy+Oz8WWWc/Qd5mDS3R2rYr/vBmdUYEVggEfr3GZjEiVLDmiiDoDwHwWaI1C/U9AK/ZbDl1O74CeKobS9BgkAVF2FCgFBYO3dYwbcfceikd2eSkI/MvFKiLNGJBdYLYD7S38FPrBya1W1k+zftb+39MZRYUqpgigcdkuI0dZbQz2CqTvaWi00Fp2VA1PpSOtmBSxSZNQKx+hwSbVJcYWSuOZvhUfH+wrEZgxiElbKBfssI21G6kdMm/wSJ7xNMueQDPFGSQjJPeXDWOXjWtFsvnRVZ+sb5oUOx33HKziShtI3il8QOGQax2s3x11bhgktyFoKC5sbPMjLllIy7+4n7zEAFCzftan833Sit73Ub1YvmQ+uh9c122NueYW23MbK0Imf9V3O+0KHemYiFlLs+g7uKvy2eMGwT8U0bkQXcWmy9oL+l+DwYwQPI8Ks23UX9RdSJl2cgWN3ARLSkXvFHstMGNdFBTYCIpjs/eSuyaZh/+2+InJATRHvLKCspwYC9nwakdEexb2FSi1B8EeF7IGH97Ct6IeqXp6UvLzfGj6e+UDILv1Mxi36ZcHAgn5fHNCF7OuxD/IQILE2OOWd3u+1FMO1TSPEZGWk9UTicYFSKR4T+uYP+NKOvFS4Ius5bP7yL6EM7b36O5Mlp0HXq6fAmWlxQiyEYhvCNGTRvXl2ieGXVXyimdyz9H9JAxU2CYqb4uyhunCR+nl+Q+uSB2kwYV+ipB7oovDpztdJ7yfA9fEcBkYVxL53lQIuqY1BH/PU4j5wqY668fMMFlnzXZcidP6cd3AjYZJgFQZiEn3oP8Z52RgOD0W1eHEreQCXp0u9IQxdLFJCd5+HkjicMpoRsPeWk+b3JQQd3eBxxXOExP20MeSTFYW4Vg+1G2wlDvhseceqEIlL+rVcj4t67uTKy81fS+CnRVcGZwwQlyCN9/gp+QPtv5edf2f8AFO1TBItWpF+sdvQF3Z1gsD++N531+18bH90EQiiKVpRvpXc1vnAJKEJF+JOoe1qyJNC5YAm6qI+XOuAeXkdgGCSOUEt6wRx9dEU35SFY73/LxTtWhjOGyQRf6NlTCjRtRGIK42nA9osw66UkU9usVZr1EhcVlcVTX7pmQ9iq2+YKE8AhqR74Ro/UUCZdJ/om3LtuqgZcpJxa3bEksQUZbLiVGy+rh2p2yiD2ZB+8JR5IV1Gnj/GDnv3LY5zv1KY1j7OZgUi1wzPaxm6La4AM4f6cbWS6OD3V83EzD7P79QLXrhZTkwoahSIXDfSuCm8dRVDok0xZBklh6Pqjv4sc+dm5QejS9eZWna",
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIID8jCCAtqgAwIBAgIUOhBPJVBb+qRxAr91sSMbsXe3Xs0wDQYJKoZIhvcNAQEL\nBQAwXTELMAkGA1UEBhMCQkUxEDAOBgNVBAcTB0FudHdlcnAxDjAMBgNVBAoTBU5v\na2lhMRYwFAYDVQQLEw1Db250YWluZXIgbGFiMRQwEgYDVQQDEwtzcmwgUm9vdCBD\nQTAeFw0yMjA3MTYwOTA3MDBaFw0yMzA3MTYwOTA3MDBaMFwxCzAJBgNVBAYTAkJF\nMRAwDgYDVQQHEwdBbnR3ZXJwMQ4wDAYDVQQKEwVOb2tpYTEWMBQGA1UECxMNQ29u\ndGFpbmVyIGxhYjETMBEGA1UEAxMKc3JsLnNybC5pbzCCASIwDQYJKoZIhvcNAQEB\nBQADggEPADCCAQoCggEBANzU7RaCl2uxO2BuGq8AcpjkHtFgBmG9TrpNeHebKZdP\n7ZxytwnMrnIfIGEGLhdLg7XmzTlU+DU1ePTOya1pk0JMCg+9YxENEMSc9mcNJizI\nspVK8rxn82d50dHW7WoLe4giNdDeUghGffavyiY6QJ5Kr79FYyTTtxu3wQFwYTcG\n5fcAZc6KvljIf9+Ps15HlSxvjS6zFlzkMkpC61oungFcszvJPSGEOtNziGS6S4wt\n5TeY1aGv13RqFxpaYabuoo3UlwgRFKoZOrFRSkh4qjbjjYErmZrmsiZLcEgB4WvI\naCGBsck9Jcql10uydnWnU9ksUg5ix6add8mdPZaHenkCAwEAAaOBqjCBpzAOBgNV\nHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1Ud\nEwEB/wQCMAAwHQYDVR0OBBYEFAA0J6IKAtGKS0k60D7+yrglr2IQMB8GA1UdIwQY\nMBaAFKfziDRGi3Qfd8szGB1x9bTWFL/2MCgGA1UdEQQhMB+CA3NybIIMY2xhYi1z\ncmwtc3Jsggpzcmwuc3JsLmlvMA0GCSqGSIb3DQEBCwUAA4IBAQBPyGDA/PauCPPT\nHk6uHQkqj6zzp2jpsQNNm7ylNLG/xf0JA9k7hsCEVZ1kw2LDC2Pl7KGUEYCdfl0X\nvz6Cho3b/C4Jn5QosrmHJQjQFDaqp/2zNhOLe7h2NhpBFIDdSbVJUM9BBNcy7WkQ\nS09z4kBrmifKmsAL7R7Tg9QChwufhfUAHFMtvItIPAwIpmTvW2zolUCpaj56YibO\nPupdRS3auBIt+8p0r+QA9SUCxfx+5dgd9EYQ9d/SOR6GYzE+Qur71HQaUazrb7zH\nDaboAO1jFTJ8T3JTAdHSY8A1YmNY7MBT3lwqkn6hM62bXlrkheif4fIt/7kMeLqt\nloap1cr9\n-----END CERTIFICATE-----\n",
+                    "authenticate-client": false
+                }
+            ]
+        },
+        "srl_nokia-json-rpc:json-rpc-server": {
+            "admin-state": "enable",
+            "network-instance": [
+                {
+                    "name": "mgmt",
+                    "http": {
+                        "admin-state": "enable"
+                    },
+                    "https": {
+                        "admin-state": "enable",
+                        "tls-profile": "clab-profile"
+                    }
+                }
+            ]
+        },
+        "srl_nokia-ssh:ssh-server": {
+            "network-instance": [
+                {
+                    "name": "mgmt",
+                    "admin-state": "enable"
+                }
+            ]
+        },
+        "srl_nokia-system-banner:banner": {
+            "login-banner": "................................................................\n:                  Welcome to Nokia SR Linux!                  :\n:              Open Network OS for the NetOps era.             :\n:                                                              :\n:    This is a freely distributed official container image.    :\n:                      Use it - Share it                       :\n:                                                              :\n: Get started: https://learn.srlinux.dev                       :\n: Container:   https://go.srlinux.dev/container-image          :\n: Docs:        https://doc.srlinux.dev/22-6                    :\n: Rel. notes:  https://doc.srlinux.dev/rn22-6-1                :\n: YANG:        https://yang.srlinux.dev/v22.6.1                :\n: Discord:     https://go.srlinux.dev/discord                  :\n: Contact:     https://go.srlinux.dev/contact-sales            :\n................................................................\n"
+        },
+        "srl_nokia-logging:logging": {
+            "buffer": [
+                {
+                    "buffer-name": "messages",
+                    "rotate": 3,
+                    "size": "10000000",
+                    "facility": [
+                        {
+                            "facility-name": "local6",
+                            "priority": {
+                                "match-above": "informational"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "buffer-name": "system",
+                    "facility": [
+                        {
+                            "facility-name": "auth",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "cron",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "daemon",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "ftp",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "kern",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "lpr",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "mail",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "news",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "syslog",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "user",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "uucp",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local0",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local1",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local2",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local3",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local4",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local5",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        },
+                        {
+                            "facility-name": "local7",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "file": [
+                {
+                    "file-name": "messages",
+                    "rotate": 3,
+                    "size": "10000000",
+                    "facility": [
+                        {
+                            "facility-name": "local6",
+                            "priority": {
+                                "match-above": "warning"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "srl_nokia-network-instance:network-instance": [
+        {
+            "name": "mgmt",
+            "type": "srl_nokia-network-instance:ip-vrf",
+            "admin-state": "enable",
+            "description": "Management network instance",
+            "interface": [
+                {
+                    "name": "mgmt0.0"
+                }
+            ],
+            "protocols": {
+                "srl_nokia-linux:linux": {
+                    "import-routes": true,
+                    "export-routes": true,
+                    "export-neighbors": true
+                }
+            }
+        }
+    ]
+}

--- a/examples/srlinux/2node-srl-with-config.pbtxt
+++ b/examples/srlinux/2node-srl-with-config.pbtxt
@@ -1,0 +1,60 @@
+# this topology consists of two Nokia SR Linux IXR-D2 nodes running 22.6.1 release
+# each of the nodes comes up with a startup config applied which is sourced from 22.6.1.cfg.json file
+# the startup config already contains a self-signed TLS cert and has gnmi server enabled
+# this allows users to deploy this topology and start using gnmi
+name: "2srl-certs"
+nodes: {
+    name: "r1"
+    type: NOKIA_SRL
+    config:{
+        # container image to use for this SR Linux pod
+        # can be cheked with `show version` cli command
+        image: "ghcr.io/nokia/srlinux:22.6.1"
+        # file property sets the path to the startup config file that srlinux will boot with
+        # the path is relative to the topology file
+        # this config file already contains tls profiles and gnmi server enabled
+        file: "22.6.1.cfg.json"
+    }
+    services:{
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services:{
+        key: 57400
+        value: {
+            name: "gnmi"
+            inside: 57400
+        }
+    }
+}
+nodes: {
+    name: "r2"
+    type: NOKIA_SRL
+    config:{
+        # container image to use for this SR Linux pod
+        # can be cheked with `show version` cli command
+        image: "ghcr.io/nokia/srlinux:22.6.1"
+        # file property sets the path to the startup config file that srlinux will boot with
+        # the path is relative to the topology file
+        # this config file already contains tls profiles and gnmi server enabled
+        file: "22.6.1.cfg.json"
+    }
+    services:{
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+}
+
+links: {
+    a_node: "r1"
+    a_int: "e1-1"
+    z_node: "r2"
+    z_int: "e1-1"
+}
+


### PR DESCRIPTION
This PR adds a new topology example for Nokia SR Linux

this topology consists of two Nokia SR Linux IXR-D2 nodes running 22.6.1 release
each of the nodes comes up with a startup config applied which is sourced from 22.6.1.cfg.json file
the startup config already contains a self-signed TLS cert and has gnmi server enabled
this allows users to deploy this topology and start using gnmi

## How to run it
using kne_cli from current main branch (I used kne_cli_dev name)

deploy kind cluster
```bash
./kne_cli_dev deploy deploy/kne/kind-bridge.yaml
```

apply srl-controller
```
kubectl apply -k https://github.com/srl-labs/srl-controller/config/default
```

create the topo
```
./kne_cli_dev create examples/srlinux/2node-srl-with-config.pbtxt
```

list services
```
❯ kubectl get svc -A
NAMESPACE            NAME                                                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                        AGE
2srl-certs           service-r1                                              LoadBalancer   10.96.183.5     172.18.0.50   22:31481/TCP,57400:31153/TCP   62s
2srl-certs           service-r2                                              LoadBalancer   10.96.139.119   172.18.0.51   22:31253/TCP                   62s
default              kubernetes                                              ClusterIP      10.96.0.1       <none>        443/TCP                        3m
kube-system          kube-dns                                                ClusterIP      10.96.0.10      <none>        53/UDP,53/TCP,9153/TCP         2m59s
srlinux-controller   srlinux-controller-controller-manager-metrics-service   ClusterIP      10.96.118.230   <none>        8443/TCP                       2m12s
```

test gnmi operations
```
gnmic -a 172.18.0.50:57400 -u admin -p admin --skip-verify cap
```