### PR TITLE
Only update kind config path if it was defined

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -94,7 +94,9 @@ func newDeployment(cfgPath string) (*deploy.Deployment, error) {
 		}
 
 		// make sure kind config file is relative to configuration.
-		v.KindConfigFile = cleanPath(v.KindConfigFile, basePath)
+		if v.KindConfigFile != "" {
+			v.KindConfigFile = cleanPath(v.KindConfigFile, basePath)
+		}
 
 		d.Cluster = v
 	default:


### PR DESCRIPTION
#166 introduced an issue when the "config" value is blank in the spec, it gets populated with a directory.  This gets passed to kind later and causes cluster creation to fail.

```
$ kne_cli deploy kne/deploy/kne/kind.yaml
INFO[0000] Reading deployment config: "/home/bstoll_google_com/kne/deploy/kne/kind.yaml"
...
INFO[0000] Creating kind cluster with: [create cluster --name kne --image kindest/node:v1.22.1 --config /home/bstoll_google_com/kne/deploy/kne]
ERROR: failed to create cluster: error reading file: read /home/bstoll_google_com/kne/deploy/kne: is a directory
Error: failed to create cluster: "/home/bstoll_google_com/go/bin/kind create cluster --name kne --image kindest/node:v1.22.1 --config /home/bstoll_google_com/kne/deploy/kne" failed: exit status 1
```

With this change, the cluster is created:

```
$ kne_cli deploy kne/deploy/kne/kind.yaml
INFO[0000] Reading deployment config: "/home/bstoll_google_com/kne/deploy/kne/kind.yaml"
...
INFO[0000] Creating kind cluster with: [create cluster --name kne --image kindest/node:v1.22.1]
...
INFO[0062] Waiting on Meshnet to be Healthy
INFO[0062] Meshnet Healthy
INFO[0062] CNI healthy
INFO[0062] Controllers deployed and healthy
INFO[0062] Deployment complete, ready for topology
```
