### PR TITLE
Support CEOS PKI certificate delay

### DIFF
--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -135,16 +135,29 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 		),
 	}
 
-	resp, err := n.cliConn.SendConfigs(cfgs)
-	if err != nil {
-		return err
+	for pkiReady := false; !pkiReady; {
+		resp, err := n.cliConn.SendConfigs(cfgs)
+		if err != nil {
+			return err
+		}
+		if resp.Failed != nil {
+			return resp.Failed
+		}
+		pkiReady = true
+		for _, r := range resp.Responses {
+			if strings.Contains(r.Result, "PKI not ready") {
+				pkiReady = false
+			}
+		}
+		if pkiReady {
+			break
+		}
+		log.Infof("%s - PKI not ready - waiting", n.Name())
+		time.Sleep(time.Second * 2)
 	}
+	log.Infof("%s - finshed cert generation", n.Name())
 
-	if resp.Failed == nil {
-		log.Infof("%s - finshed cert generation", n.Name())
-	}
-
-	return resp.Failed
+	return nil
 }
 
 func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -135,7 +135,8 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 		),
 	}
 
-	for pkiReady := false; !pkiReady; {
+	pkiReady := false
+	for !pkiReady {
 		resp, err := n.cliConn.SendConfigs(cfgs)
 		if err != nil {
 			return err
@@ -152,7 +153,7 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 		if pkiReady {
 			break
 		}
-		log.Infof("%s - PKI not ready - waiting", n.Name())
+		log.Debugf("%s - PKI not ready - waiting", n.Name())
 		time.Sleep(time.Second * 2)
 	}
 	log.Infof("%s - finshed cert generation", n.Name())

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -256,6 +256,13 @@ func TestGenerateSelfSigned(t *testing.T) {
 			testFile: "generate_certificate_success",
 		},
 		{
+			// successfully configure certificate with delay
+			desc:     "success with delay",
+			wantErr:  false,
+			ni:       ni,
+			testFile: "generate_certificate_success_delay",
+		},
+		{
 			// device returns "% Invalid input" -- we expect to fail
 			desc:     "failure",
 			wantErr:  true,

--- a/topo/node/ceos/generate_certificate_success_delay
+++ b/topo/node/ceos/generate_certificate_success_delay
@@ -1,0 +1,28 @@
+spine1>enable
+spine1#
+spine1#
+spine1#terminal width 32767
+Width set to 32767 columns.
+spine1#
+spine1#terminal length 0
+Pagination disabled.
+spine1#
+spine1#configure terminal
+spine1(config)#
+spine1(config)#security pki key generate rsa 2048 my_key
+% PKI not ready
+spine1(config)#security pki certificate generate self-signed my_cert key my_key parameters common-name pod1
+% PKI not ready
+spine1(config)#
+spine1(config)#security pki key generate rsa 2048 my_key
+% PKI not ready
+spine1(config)#security pki certificate generate self-signed my_cert key my_key parameters common-name pod1
+% PKI not ready
+spine1(config)#
+spine1(config)#security pki key generate rsa 2048 my_key
+spine1(config)#security pki certificate generate self-signed my_cert key my_key parameters common-name pod1
+certificate:my_cert generated
+spine1(config)#
+spine1(config)#end
+spine1#
+spine1#


### PR DESCRIPTION
On my CEOS containers, I get the following CLI output from PKI generation after #165 (on both commands):

`% PKI not ready`

I am not sure if this error message/delay is version-dependent or varies depending on the host system specs.  The result code for CLI commands is still err==nil.  This non-error was resulting in the GNMI service failing to start:
```
localhost#show management api gnmi
Octa: enabled

Transport: default
Enabled: no
Server: not yet running
Error: SSL profile "octa-ssl-profile" not in valid state
SSL profile: none
QoS DSCP: none
Authorization required: no
Notification timestamp: last change time
Listen addresses:
```

This PR checks for the message and reruns commands until this output is not seen:

```
...
INFO[0000] Node "dut" resource created
INFO[0000] dut - generating self signed certs
INFO[0000] dut - waiting for pod to be running
INFO[0001] dut - pod running.
INFO[0029] dut - PKI not ready - waiting
INFO[0034] dut - finshed cert generation
INFO[0034] Node "dut": Status RUNNING
INFO[0034] Topology "arista-ceos" created
INFO[0034] Pods:
INFO[0034] dut
...
```