### PR TITLE
Fix registration issues

### DIFF
--- a/api/clientset/v1beta1/fake/fake.go
+++ b/api/clientset/v1beta1/fake/fake.go
@@ -3,9 +3,7 @@ package fake
 import (
 	toplogyv1client "github.com/openconfig/kne/api/clientset/v1beta1"
 	topologyv1 "github.com/openconfig/kne/api/types/v1beta1"
-
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	dfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
 )
@@ -15,9 +13,7 @@ func NewSimpleClientset(objects ...runtime.Object) (*toplogyv1client.Clientset, 
 	if err != nil {
 		return nil, err
 	}
-	c := dfake.NewSimpleDynamicClientWithCustomListKinds(topologyv1.Scheme, map[schema.GroupVersionResource]string{
-		toplogyv1client.GVR(): "TopologyList",
-	}, objects...)
+	c := dfake.NewSimpleDynamicClient(topologyv1.Scheme, objects...)
 	cs.SetDynamicClient(c.Resource(toplogyv1client.GVR()))
 	return cs, nil
 }

--- a/api/clientset/v1beta1/topology_test.go
+++ b/api/clientset/v1beta1/topology_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
@@ -122,9 +121,7 @@ func setUp(t *testing.T) *Clientset {
 	if err != nil {
 		t.Fatalf("failed to create client set")
 	}
-	f := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(topologyv1.Scheme, map[schema.GroupVersionResource]string{
-		GVR(): "TopologyList",
-	}, objs...)
+	f := dynamicfake.NewSimpleDynamicClient(topologyv1.Scheme, objs...)
 	f.PrependWatchReactor("*", func(action ktest.Action) (bool, watch.Interface, error) {
 		wAction, ok := action.(ktest.WatchAction)
 		if !ok {

--- a/api/types/v1beta1/register.go
+++ b/api/types/v1beta1/register.go
@@ -20,8 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const GroupName = "networkop.co.uk"
-const GroupVersion = "v1beta1"
+const (
+	GroupName    = "networkop.co.uk"
+	GroupVersion = "v1beta1"
+)
 
 var (
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -977,6 +977,10 @@ func TestResources(t *testing.T) {
 			ConfigMaps: map[string]*corev1.ConfigMap{},
 			Topologies: map[string]*topologyv1.Topology{
 				"t1": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Topology",
+						APIVersion: "networkop.co.uk/v1beta1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "t1",
 						Namespace: "test",


### PR DESCRIPTION
turns out that the pluralization was actually for the resource name "topologies", not the List struct

making the changes to TopologyList -> TopologiesList actually caused more issues with the mapping (it tries to do additional pluralization on names ending in "s" -> "es")

```
panic: coding error: you must register resource to list kind for every resource you're going to LIST when creating the client. 
See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme:
networkop.co.uk/v1beta1, Resource=topologies out of 
map[
    /v1,
    Resource=apigroups:APIGroupList /v1,
    Resource=apiresources:APIResourceList networkop.co.uk/v1beta1,
    Resource=topologieses:TopologiesList,
]
```
Now that the scheme is populated with the topology crd structs in the init(), the additional registrations are not needed

Also changed the Create() method to lookup the gvk instead of hardcoding it
