### PR TITLE
Update operator to v1.0.2 (see operator release page)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openconfig/kne
 go 1.18
 
 require (
-	github.com/aristanetworks/arista-ceoslab-operator v1.0.1
+	github.com/aristanetworks/arista-ceoslab-operator v1.0.2
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/aristanetworks/arista-ceoslab-operator v1.0.1 h1:wO998Zy7pWzt0/rE/dGZg8VONH2a0iI62rj3nj9EsGs=
-github.com/aristanetworks/arista-ceoslab-operator v1.0.1/go.mod h1:4n5xLENCbpMzdlbDZm+W8AMwYJxfiFdhhdTpW3y7zOw=
+github.com/aristanetworks/arista-ceoslab-operator v1.0.2 h1:97W6uMKEyC9s2GiA6GkmOtkvwOwQw817z3507n8CKPw=
+github.com/aristanetworks/arista-ceoslab-operator v1.0.2/go.mod h1:4n5xLENCbpMzdlbDZm+W8AMwYJxfiFdhhdTpW3y7zOw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Sorry about this, but I made a mistake in the operator repository when updating some dependencies. I forgot to update the release version in the Makefile file so any naive application of the generated manifest will pull images at v1.0.0 even if you checkout the repo at v1.0.1. Images built locally are also tagged incorrectly. The docker action to build images remotely does not use the Makefile so the image tagged v1.0.1 in ghcr is consistent with the source. I fixed this issue in v1.0.2.

This isn't immediately causing a breakage because there were no API changes between v1.0.0 and v1.0.1.