### PR TITLE
Remove duplicate steps in the postsubmit

### DIFF
--- a/cloudbuild/postsubmit.yaml
+++ b/cloudbuild/postsubmit.yaml
@@ -1,22 +1,4 @@
 steps:
-  - id: go_version
-    name: golang
-    args: ["go", "version"]
-
-  - id: go_build_cli
-    name: golang
-    dir: "kne_cli"
-    args: ["go", "build", "main.go"]
-
-  - id: go_build_controller_server
-    name: golang
-    dir: "controller/server"
-    args: ["go", "build", "main.go"]
-
-  - id: go_test
-    name: golang
-    args: ["go", "test", "-v", "./..."]
-
   - id: packer_build_external
     name: "us-west1-docker.pkg.dev/gep-kne/packer/packer"
     args: ["build", "cloudbuild/external.pkr.hcl"]
@@ -26,7 +8,6 @@ steps:
       "PKR_VAR_branch_name=$BRANCH_NAME",
       "PKR_VAR_zone=${_ZONE}",
     ]
-    waitFor: ["go_test"]
 
   - id: packer_build_internal
     name: "us-west1-docker.pkg.dev/gep-kne/packer/packer"
@@ -37,7 +18,7 @@ steps:
       "PKR_VAR_branch_name=$BRANCH_NAME",
       "PKR_VAR_zone=${_ZONE}",
     ]
-    waitFor: ["go_test"]
+    waitFor: ["-"] # run the builds concurrently
 
 timeout: 1800s
 


### PR DESCRIPTION
The steps removed from the post submit are redundant due to the github actions that run before a PR can be merged. Now that there is a presubmit the overall flow is as follows:

1. Lint + Build + Test are run automatically on any new PR
2. If all checks pass then a manual review from repo owner is required
3. Presubmit (integration test using ondatra coming soon) is required by an a repo owner commenting `/gcbrun` on the PR (after code review)
4. The postsubmit (builds VM images) is triggered automatically on merge