### PR TITLE
8000e config file typo fix

### DIFF
--- a/examples/cisco/e8000/r1.config
+++ b/examples/cisco/e8000/r1.config
@@ -6,7 +6,7 @@ username cisco
  group cisco-support
  password 7 01100F175804575D72
 ! 
-interface FourGigabitEthernet0/0/0/0
+interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.1 255.255.255.0
 !
 ! Configure BGP

--- a/examples/cisco/e8000/r2.config
+++ b/examples/cisco/e8000/r2.config
@@ -6,7 +6,7 @@ username cisco
  group cisco-support
  password 7 01100F175804575D72
 ! 
-interface FourGigabitEthernet0/0/0/0
+interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.2 255.255.255.0
 !
 ! Configure BGP


### PR DESCRIPTION
FourGigabitEthernet0/0/0/0 is not an interface in 8000e.
Changed to FourHundredGigE0/0/0/0.