### PR TITLE
Change cisco default image based on model if unspecified

### DIFF
--- a/examples/cisco/e8000/2node-e8000.pb.txt
+++ b/examples/cisco/e8000/2node-e8000.pb.txt
@@ -7,7 +7,6 @@ nodes: {
     os: "ios-xr"
     config: {
         file: "r1.config"
-        image: "c8201:latest"
     }
     services:{
         key: 22
@@ -38,7 +37,6 @@ nodes: {
     os: "ios-xr"
     config: {
         file: "r2.config"
-        image: "c8201:latest"
     }
     services:{
         key: 22

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -361,9 +361,6 @@ func defaults(pb *tpb.Node) (*tpb.Node, error) {
 			"vendor": tpb.Vendor_CISCO.String(),
 		}
 	}
-	if pb.Config.Image == "" {
-		pb.Config.Image = "ios-xr:latest"
-	}
 	if pb.Config.EntryCommand == "" {
 		pb.Config.EntryCommand = fmt.Sprintf("kubectl exec -it %s -- bash", pb.Name)
 	}
@@ -374,10 +371,16 @@ func defaults(pb *tpb.Node) (*tpb.Node, error) {
 		if err := setXRDEnv(pb); err != nil {
 			return nil, err
 		}
+		if pb.Config.Image == "" {
+			pb.Config.Image = "xrd:latest"
+		}
 	//nolint:goconst
 	case "8201", "8202", "8201-32FH", "8102-64H", "8101-32H":
 		if err := setE8000Env(pb); err != nil {
 			return nil, err
+		}
+		if pb.Config.Image == "" {
+			pb.Config.Image = "e8000:latest"
 		}
 	}
 	return pb, nil

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -115,7 +115,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "xrd:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":        "test/interface",
 					"XR_EVERY_BOOT_CONFIG": "/foo",
@@ -185,7 +185,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "xrd:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":        "linux:eth1,xr_name=GigabitEthernet0/0/0/0;linux:eth2,xr_name=GIG1;linux:eth3,xr_name=GigabitEthernet0/0/0/2",
 					"XR_EVERY_BOOT_CONFIG": "/foo",
@@ -259,7 +259,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "e8000:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":                  "MgmtEther0/RP0/CPU0/0:eth0,FourHundredGigE0/0/0/0:eth1,GIG1:eth2,FourHundredGigE0/0/0/23:eth24,HundredGigE0/0/0/24:eth25,HundredGigE0/0/0/35:eth36",
 					"XR_CHECKSUM_OFFLOAD_COUNTERACT": "MgmtEther0/RP0/CPU0/0,FourHundredGigE0/0/0/0,GIG1,FourHundredGigE0/0/0/23,HundredGigE0/0/0/24,HundredGigE0/0/0/35",
@@ -352,7 +352,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "e8000:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":                  "MgmtEther0/RP0/CPU0/0:eth0,HundredGigE0/0/0/0:eth1,GIG1:eth2,HundredGigE0/0/0/47:eth48,FourHundredGigE0/0/0/48:eth49,FourHundredGigE0/0/0/59:eth60,HundredGigE0/0/0/60:eth61,HundredGigE0/0/0/71:eth72",
 					"XR_CHECKSUM_OFFLOAD_COUNTERACT": "MgmtEther0/RP0/CPU0/0,HundredGigE0/0/0/0,GIG1,HundredGigE0/0/0/47,FourHundredGigE0/0/0/48,FourHundredGigE0/0/0/59,HundredGigE0/0/0/60,HundredGigE0/0/0/71",
@@ -452,7 +452,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "e8000:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":                  "MgmtEther0/RP0/CPU0/0:eth0,FourHundredGigE0/0/0/0:eth1,GIG1:eth2,FourHundredGigE0/0/0/31:eth32",
 					"XR_CHECKSUM_OFFLOAD_COUNTERACT": "MgmtEther0/RP0/CPU0/0,FourHundredGigE0/0/0/0,GIG1,FourHundredGigE0/0/0/31",
@@ -522,7 +522,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "e8000:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":                  "MgmtEther0/RP0/CPU0/0:eth0,HundredGigE0/0/0/0:eth1,GIG1:eth2,HundredGigE0/0/0/31:eth32",
 					"XR_CHECKSUM_OFFLOAD_COUNTERACT": "MgmtEther0/RP0/CPU0/0,HundredGigE0/0/0/0,GIG1,HundredGigE0/0/0/31",
@@ -622,7 +622,7 @@ func TestNew(t *testing.T) {
 				"vendor": tpb.Vendor_CISCO.String(),
 			},
 			Config: &tpb.Config{
-				Image: "ios-xr:latest",
+				Image: "e8000:latest",
 				Env: map[string]string{
 					"XR_INTERFACES":                  "MgmtEther0/RP0/CPU0/0:eth0,HundredGigE0/0/0/0:eth1,GIG1:eth2,HundredGigE0/0/0/63:eth64",
 					"XR_CHECKSUM_OFFLOAD_COUNTERACT": "MgmtEther0/RP0/CPU0/0,HundredGigE0/0/0/0,GIG1,HundredGigE0/0/0/63",


### PR DESCRIPTION
This is to support a user loading both a e8000 image and xrd image into the cluster instead of a single ios-xr image