### PR TITLE
Configure sudoless docker

### DIFF
--- a/cloudbuild/internal.pkr.hcl
+++ b/cloudbuild/internal.pkr.hcl
@@ -69,7 +69,8 @@ build {
       "sudo usermod -aG docker $USER",
       "sudo docker version",
       "echo Pulling containers...",
-      "sudo gcloud auth configure-docker us-west1-docker.pkg.dev -q",
+      "gcloud auth configure-docker us-west1-docker.pkg.dev -q", # configure sudoless docker
+      "sudo gcloud auth configure-docker us-west1-docker.pkg.dev -q", # configure docker with sudo
       "sudo docker pull us-west1-docker.pkg.dev/gep-kne/arista/ceos:ga",
       "sudo docker pull us-west1-docker.pkg.dev/gep-kne/cisco/ios-xr/xrd:ga",
       "sudo docker pull us-west1-docker.pkg.dev/gep-kne/cisco/ios-xr/e8000:ga",


### PR DESCRIPTION
Turns out that docker needs to be configured with gcloud for both sudo/sudoless situations. sudo for packer provisioning and sudoless for general usage after image boots