### PR TITLE
configure inotify

### DIFF
--- a/cloudbuild/external.pkr.hcl
+++ b/cloudbuild/external.pkr.hcl
@@ -68,6 +68,8 @@ build {
       "sudo apt-get -o DPkg::Lock::Timeout=60 install docker-ce docker-ce-cli containerd.io build-essential -y",
       "sudo usermod -aG docker $USER",
       "sudo docker version",
+      "sudo sysctl fs.inotify.max_user_instances=64000", # configure inotify for cisco containers
+      "sudo sysctl -p",
     ]
   }
 

--- a/cloudbuild/internal.pkr.hcl
+++ b/cloudbuild/internal.pkr.hcl
@@ -68,6 +68,8 @@ build {
       "sudo apt-get -o DPkg::Lock::Timeout=60 install docker-ce docker-ce-cli containerd.io build-essential -y",
       "sudo usermod -aG docker $USER",
       "sudo docker version",
+      "sudo sysctl fs.inotify.max_user_instances=64000", # configure inotify for cisco containers
+      "sudo sysctl -p",
       "echo Pulling containers...",
       "gcloud auth configure-docker us-west1-docker.pkg.dev -q", # configure sudoless docker
       "sudo gcloud auth configure-docker us-west1-docker.pkg.dev -q", # configure docker with sudo


### PR DESCRIPTION
This is to fix the following issue with xrd:

```
ERROR - Not enough inotify instance resource available for new XRd instance.
Each XRd instance is expected to need 4000 of each - please consider
setting the limits high (e.g. 64000, or higher).
```