### PR TITLE
Allow for '+' extensions to patch revision

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -338,7 +338,8 @@ func getVersion(s string) (*version, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert minor version: %s", s)
 	}
-	v.Patch, err = strconv.Atoi(versions[2])
+	patch := strings.Split(versions[2], "+")
+	v.Patch, err = strconv.Atoi(patch[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert patch version: %s", s)
 	}


### PR DESCRIPTION
Should be pretty harmless, but lets me use vendored k8s releases on external clusters.