### PR TITLE
Add sudo to `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,4 @@ build:
 .PHONY: install
 ## Install kne cli binary to user's local bin dir
 install: build
-	mv $(KNE_CLI_BIN) $(INSTALL_DIR)
+	sudo mv $(KNE_CLI_BIN) $(INSTALL_DIR)


### PR DESCRIPTION
/usr/local/bin is a root-owned directory, so sudo is necessary to avoid `make install` failing due to lack of permission.