### PR TITLE
Add logshim package in preparation for migrating from logrus to klog.

### DIFF
--- a/docs/create_topology.md
+++ b/docs/create_topology.md
@@ -39,7 +39,7 @@ A deployment yaml file specifies 4 things (*optional in italics*):
 4. *A list of controller specs*
 
 A full definition for valid fields in the deployment yaml can be found within
-[deploy/deploy.go](https://github.com/openconfig/kne/deploy/deploy.go#L212).
+[deploy/deploy.go](https://github.com/openconfig/kne/blob/816133f1cb563555bcdcb12eb27874b77dd41d1d/deploy/deploy.go#L212).
 
 Expand the below section for a full description of all fields in the deployment
 yaml.
@@ -228,7 +228,7 @@ Global Flags:
 ```
 
 A topology file is a textproto of the `Topology`
-[message](https://github.com/openconfig/kne/proto/topo.proto#L26).
+[message](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/proto/topo.proto#L26).
 This file specifies all of the nodes and links of your desired topology. In the
 node definitions interfaces, services, and initial configs can be specified.
 
@@ -257,7 +257,7 @@ Container images can be hosted in multiple locations. For example
 [DockerHub](https://hub.docker.com/) hosts open sourced containers. [Google
 Artifact Registries](https://cloud.google.com/artifact-registry) can be used to
 host images with access control. The [KNE topology
-proto](https://github.com/openconfig/kne/proto/topo.proto#L117),
+proto](https://github.com/openconfig/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/kne/proto/topo.proto#L117),
 the manifests, and controllers can all specify containers that get pulled from
 their source locations and get used in the cluster.
 

--- a/docs/create_topology.md
+++ b/docs/create_topology.md
@@ -39,7 +39,7 @@ A deployment yaml file specifies 4 things (*optional in italics*):
 4. *A list of controller specs*
 
 A full definition for valid fields in the deployment yaml can be found within
-[deploy/deploy.go](https://github.com/openconfig/kne/blob/816133f1cb563555bcdcb12eb27874b77dd41d1d/deploy/deploy.go#L212).
+[deploy/deploy.go](https://github.com/openconfig/kne/deploy/deploy.go#L212).
 
 Expand the below section for a full description of all fields in the deployment
 yaml.
@@ -152,7 +152,7 @@ Field       | Type   | Description
 ---
 
 The basic deployment yaml file can be found in the GitHub repo at
-[deploy/kne/kind-bridge.yaml](https://github.com/openconfig/kne/blob/5e6cf1cbc0748bb48ebf49039bd0ad592378357a/deploy/kne/kind-bridge.yaml).
+[deploy/kne/kind-bridge.yaml](https://github.com/openconfig/kne/deploy/kne/kind-bridge.yaml).
 
 This config specifies `kind` as the cluster, `metallb` as the ingress, and
 `meshnet` as the CNI. Additionally, the config instructs `kindnet` CNI to use
@@ -228,16 +228,16 @@ Global Flags:
 ```
 
 A topology file is a textproto of the `Topology`
-[message](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/proto/topo.proto#L26).
+[message](https://github.com/openconfig/kne/proto/topo.proto#L26).
 This file specifies all of the nodes and links of your desired topology. In the
 node definitions interfaces, services, and initial configs can be specified.
 
 An example topology containing 3 Arista `cEOS` nodes and 2 Keysight `ixia-tg`
 ATEs can be found at
-[examples/host/3node-host.pb.txt](https://github.com/openconfig/kne/blob/main/examples/host/3node-host.pb.txt).
+[examples/arista/ceos-traffic/ceos-traffic.pb.txt](https://github.com/openconfig/kne/examples/arista/ceos-traffic/ceos-traffic.pb.txt).
 
 The initial vendor router configs referenced in the topology are found
-[here](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/examples/ceos-withtraffic/).
+[here](https://github.com/openconfig/kne/examples/arista/ceos-traffic)
 See the [push config](interact_topology.md#push_config) section for details
 about pushing config after initial creation.
 
@@ -257,7 +257,7 @@ Container images can be hosted in multiple locations. For example
 [DockerHub](https://hub.docker.com/) hosts open sourced containers. [Google
 Artifact Registries](https://cloud.google.com/artifact-registry) can be used to
 host images with access control. The [KNE topology
-proto](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/proto/topo.proto#L117),
+proto](https://github.com/openconfig/kne/proto/topo.proto#L117),
 the manifests, and controllers can all specify containers that get pulled from
 their source locations and get used in the cluster.
 

--- a/docs/create_topology.md
+++ b/docs/create_topology.md
@@ -234,7 +234,8 @@ node definitions interfaces, services, and initial configs can be specified.
 
 An example topology containing 3 Arista `cEOS` nodes and 2 Keysight `ixia-tg`
 ATEs can be found at
-[examples/3node-withtraffic.pb.txt](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/examples/3node-withtraffic.pb.txt).
+[examples/host/3node-host.pb.txt](https://github.com/openconfig/kne/blob/main/examples/host/3node-host.pb.txt).
+
 The initial vendor router configs referenced in the topology are found
 [here](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/examples/ceos-withtraffic/).
 See the [push config](interact_topology.md#push_config) section for details

--- a/docs/create_topology.md
+++ b/docs/create_topology.md
@@ -104,7 +104,7 @@ Field  | Type      | Description
 
 Field       | Type   | Description
 ----------- | ------ | -----------
-`manifests` | string | Path of the directory holding the manifests to create Meshnet in the cluster. The directory is expected to contain a file with the name `kustomization.yaml`. The validated manifest for use with KNE can be found [here](https://github.com/openconfig/kne/tree/main/manifests/meshnet/base).
+`manifests` | string | Path of the directory holding the manifests to create Meshnet in the cluster. The directory is expected to contain a file with the name `kustomization.yaml`. The validated manifest for use with KNE can be found [here](https://github.com/openconfig/kne/tree/main/manifests/meshnet).
 
 ### Controllers
 
@@ -152,7 +152,7 @@ Field       | Type   | Description
 ---
 
 The basic deployment yaml file can be found in the GitHub repo at
-[deploy/kne/kind-bridge.yaml](https://github.com/openconfig/kne/deploy/kne/kind-bridge.yaml).
+[deploy/kne/kind-bridge.yaml](https://github.com/openconfig/kne/tree/main/deploy/kne/kind-bridge.yaml).
 
 This config specifies `kind` as the cluster, `metallb` as the ingress, and
 `meshnet` as the CNI. Additionally, the config instructs `kindnet` CNI to use
@@ -190,7 +190,7 @@ kubectl apply -f https://github.com/open-traffic-generator/ixia-c-operator/relea
 > instead of the default `ptp` cluster CNI that `kind` uses.
 
 ```bash
-kubectl apply -k https://github.com/srl-labs/srl-controller/config/default
+kubectl apply -k https://github.com/srl-labs/srl-controller/tree/main/config/default
 ```
 
 See more on the
@@ -234,10 +234,10 @@ node definitions interfaces, services, and initial configs can be specified.
 
 An example topology containing 3 Arista `cEOS` nodes and 2 Keysight `ixia-tg`
 ATEs can be found at
-[examples/arista/ceos-traffic/ceos-traffic.pb.txt](https://github.com/openconfig/kne/examples/arista/ceos-traffic/ceos-traffic.pb.txt).
+[examples/arista/ceos-traffic/ceos-traffic.pb.txt](https://github.com/openconfig/kne/tree/main/examples/arista/ceos-traffic/ceos-traffic.pb.txt).
 
 The initial vendor router configs referenced in the topology are found
-[here](https://github.com/openconfig/kne/examples/arista/ceos-traffic)
+[here](https://github.com/openconfig/kne/tree/main/examples/arista/ceos-traffic)
 See the [push config](interact_topology.md#push_config) section for details
 about pushing config after initial creation.
 
@@ -257,7 +257,7 @@ Container images can be hosted in multiple locations. For example
 [DockerHub](https://hub.docker.com/) hosts open sourced containers. [Google
 Artifact Registries](https://cloud.google.com/artifact-registry) can be used to
 host images with access control. The [KNE topology
-proto](https://github.com/openconfig/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/kne/proto/topo.proto#L117),
+proto](https://github.com/openconfig/kne/blob/df91c62eb7e2a1abbf0a803f5151dc365b6f61da/proto/topo.proto#L117),
 the manifests, and controllers can all specify containers that get pulled from
 their source locations and get used in the cluster.
 

--- a/logshim/logshim.go
+++ b/logshim/logshim.go
@@ -1,0 +1,113 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logshim provides a shim to send an io.Writer to a logger, one line at
+// a time.  Normally only lines terminated with a newline are sent.  If a
+// partial line is sent it will be buffered for up to one minute waiting for the
+// rest of the line.  After one minute it will be sent as a line.
+package logshim
+
+import (
+	"bytes"
+	"sync"
+	"time"
+)
+
+type shim struct {
+	mu       sync.Mutex
+	partial  []byte
+	timer    *time.Timer
+	cancel   chan struct{} // Closed when Close is called
+	canceled chan struct{} // Closed when final data is flushed
+	write    func(...interface{})
+}
+
+const flushTimeout = time.Minute
+
+var testChannel chan struct{}
+
+// New returns an io.Writer that sends complete lines to the function f.  Each
+// complete line is written to f individually. Incomplete lines way up to one
+// minute for additional data before flushing in the background.
+func New(f func(...interface{})) *shim {
+	s := &shim{
+		timer:    time.NewTimer(time.Hour),
+		cancel:   make(chan struct{}),
+		canceled: make(chan struct{}),
+		write:    f,
+	}
+	s.timer.Stop()
+	go func() {
+		for {
+			select {
+			case <-s.timer.C:
+				s.flush()
+			case <-s.cancel:
+				s.flush()
+				close(s.canceled)
+				return
+			}
+		}
+	}()
+	return s
+}
+
+// Close releases resources used by s.  Close does not return until any buffered
+// data has been written.
+func (s *shim) Close() {
+	close(s.cancel)
+	<-s.canceled
+}
+
+// Write implements io.Writer.
+func (s *shim) Write(buf []byte) error {
+	// Prepend anything leftover from the previous write and then split into
+	// lines.  If buf does not terminate in a newline then save the last
+	// line to prefix the next write.
+	s.mu.Lock()
+	buf = append(s.partial, buf...)
+	lines := bytes.Split(buf, []byte{'\n'})
+
+	if buf[len(buf)-1] != '\n' {
+		s.partial = lines[len(lines)-1]
+		lines = lines[:len(lines)-1]
+		s.timer.Stop()
+		s.timer.Reset(flushTimeout)
+	} else {
+		s.partial = nil
+	}
+	s.mu.Unlock()
+
+	for _, line := range lines {
+		s.write(string(line))
+	}
+	return nil
+}
+
+// flush flushes any partial output.
+func (s *shim) flush() {
+	s.mu.Lock()
+	s.timer.Stop()
+	line := s.partial
+	s.partial = nil
+	s.mu.Unlock()
+
+	if len(line) > 0 {
+		s.write(string(line))
+	}
+	if testChannel != nil {
+		close(testChannel)
+		testChannel = nil
+	}
+}

--- a/logshim/logshim.go
+++ b/logshim/logshim.go
@@ -71,7 +71,9 @@ func (s *shim) Close() {
 }
 
 // Write implements io.Writer.
-func (s *shim) Write(buf []byte) error {
+func (s *shim) Write(buf []byte) (int, error) {
+	n := len(buf)
+
 	// Prepend anything leftover from the previous write and then split into
 	// lines.  If buf does not terminate in a newline then save the last
 	// line to prefix the next write.
@@ -92,7 +94,7 @@ func (s *shim) Write(buf []byte) error {
 	for _, line := range lines {
 		s.write(string(line))
 	}
-	return nil
+	return n, nil
 }
 
 // flush flushes any partial output.

--- a/logshim/logshim.go
+++ b/logshim/logshim.go
@@ -38,8 +38,8 @@ const flushTimeout = time.Minute
 var testChannel chan struct{}
 
 // New returns an io.Writer that sends complete lines to the function f.  Each
-// complete line is written to f individually. Incomplete lines way up to one
-// minute for additional data before flushing in the background.
+// complete line is written to f individually. Incomplete lines may wait up to
+// one minute for additional data before flushing in the background.
 func New(f func(...interface{})) *shim {
 	s := &shim{
 		timer:    time.NewTimer(time.Hour),

--- a/logshim/logshim_test.go
+++ b/logshim/logshim_test.go
@@ -49,13 +49,13 @@ partial line 1`))
 	s.timer.Reset(1)
 	<-testChannel
 	if got := b.String(); got != want2 {
-		t.Errorf("First: Got %q, want %q", got, want1)
+		t.Errorf("First: Got %q, want %q", got, want2)
 	}
 
 	// Write another partial line and close the shim
 	s.Write([]byte(`partial line 2`))
 	s.Close()
 	if got := b.String(); got != want3 {
-		t.Errorf("Second: Got %q, want %q", got, want2)
+		t.Errorf("Second: Got %q, want %q", got, want3)
 	}
 }

--- a/logshim/logshim_test.go
+++ b/logshim/logshim_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logshim
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestShim(t *testing.T) {
+	var b bytes.Buffer
+
+	s := New(func(args ...interface{}) {
+		b.Write([]byte("Prefix:"))
+		fmt.Fprintln(&b, args...)
+	})
+	want1 := `Prefix:Line 1
+Prefix:Line 2
+Prefix:Line 3
+`
+	want2 := want1 + `Prefix:partial line 1
+`
+	want3 := want2 + `Prefix:partial line 2
+`
+	// Writing with a partial line.
+	s.Write([]byte(`Line 1
+Line 2
+Line 3
+partial line 1`))
+	if got := b.String(); got != want1 {
+		t.Errorf("First: Got %q, want %q", got, want1)
+	}
+
+	// Force the timer to go off
+	testChannel = make(chan struct{})
+	s.timer.Reset(1)
+	<-testChannel
+	if got := b.String(); got != want2 {
+		t.Errorf("First: Got %q, want %q", got, want1)
+	}
+
+	// Write another partial line and close the shim
+	s.Write([]byte(`partial line 2`))
+	s.Close()
+	if got := b.String(); got != want3 {
+		t.Errorf("Second: Got %q, want %q", got, want2)
+	}
+}


### PR DESCRIPTION
This package enables sending standard error output to a logger, one line at a time.

I expect to use it in deploy by setting the execer's stderr to a logshim that sends the lines to the logger of our choice.