### PR TITLE
Print log files to stderr not stdout

### DIFF
--- a/kne_cli/main.go
+++ b/kne_cli/main.go
@@ -93,9 +93,9 @@ func flushLogs() {
 	}
 	if len(files) > 0 {
 		sort.Strings(files)
-		fmt.Printf("Log files can be found in:\n")
+		fmt.Fprintf(os.Stderr, "Log files can be found in:\n")
 		for _, file := range files {
-			fmt.Printf("    %s\n", filepath.Join(logdir, file))
+			fmt.Fprintf(os.Stderr, "    %s\n", filepath.Join(logdir, file))
 		}
 	}
 }


### PR DESCRIPTION
Print log files to stderr not stdout so that proto output can be unmarshaled as is.