### PR TITLE
Default to using OC yang models in SR Linux gNMI server

### DIFF
--- a/examples/nokia/srlinux-services/srl-openconfig.cfg.json
+++ b/examples/nokia/srlinux-services/srl-openconfig.cfg.json
@@ -2150,6 +2150,7 @@
         {
           "name": "mgmt",
           "admin-state": "enable",
+          "yang-models": "openconfig",
           "tls-profile": "kne-profile"
         }
       ],


### PR DESCRIPTION
As per https://github.com/openconfig/reference/blob/master/rpc/gnmi/mixed-schema.md#special-values-of-origin the default origin value should be `openconfig`.

On SR Linux this is a configurable knob, which should be set to `openconfig`.