### PR TITLE
Update cisco 8000e to include all services

### DIFF
--- a/examples/cisco/8000e/8000e-ixia.pb.txt
+++ b/examples/cisco/8000e/8000e-ixia.pb.txt
@@ -1,16 +1,11 @@
 name: "cisco-ixia"
 nodes: {
-    name: "vxr"
+    name: "8000e"
     vendor: CISCO
     model: "8201"
     os: "ios-xr"
     config: {
-        image: "ios-xr:latest" # please update the image
         file: "r1.config"
-    }
-    constraints:{
-        key: "memory"
-        value: "20Gi"
     }
     services:{
         key: 22
@@ -20,34 +15,34 @@ nodes: {
         }
     }
     services:{
-        key: 57400
+        key: 9339
         value: {
             name: "gnmi"
-            outside: 57400
+            outside: 9339
             inside: 57400
         }
     }
    services:{
-        key: 57401
+        key: 9340
         value: {
             name: "gribi"
-            outside: 57401
+            outside: 9340
             inside: 57400
         }
     }
    services:{
-        key: 57402
+        key: 9337
         value: {
             name: "gnoi"
-            outside: 57402
+            outside: 9337
             inside: 57400
         }
     }
    services:{
-        key: 57403
+        key: 9559
         value: {
             name: "p4rt"
-            outside: 57403
+            outside: 9559
             inside: 57400
         }
     }
@@ -80,7 +75,7 @@ nodes: {
 nodes: {
     name: "otg"
     vendor: KEYSIGHT
-    version: "0.0.1-3724" # Please update this with the local version from ixiatg-configmap.yaml
+    version: "0.0.1-9999" # Please update this with the local version from ixiatg-configmap.yaml
     services: {
         key: 8443
         value: {
@@ -105,25 +100,25 @@ nodes: {
 }
 
 links: {
-    a_node: "otg"
+    a_node: "8000e"
     a_int: "eth1"
-    z_node: "vxr"
+    z_node: "otg"
     z_int: "eth1"
 }
 links: {
-    a_node: "vxr"
+    a_node: "8000e"
     a_int: "eth2"
     z_node: "otg"
     z_int: "eth2"
 }
 links: {
-    a_node: "vxr"
+    a_node: "8000e"
     a_int: "eth3"
     z_node: "otg"
     z_int: "eth3"
 }
 links: {
-    a_node: "vxr"
+    a_node: "8000e"
     a_int: "eth4"
     z_node: "otg"
     z_int: "eth4"

--- a/examples/cisco/8000e/8000e-ixia.pb.txt
+++ b/examples/cisco/8000e/8000e-ixia.pb.txt
@@ -12,10 +12,6 @@ nodes: {
         key: "memory"
         value: "20Gi"
     }
-   constraints:{
-        key: "memory"
-        value: "20Gi"
-    }
     services:{
         key: 22
         value: {

--- a/examples/cisco/8000e/8000e-ixia.pb.txt
+++ b/examples/cisco/8000e/8000e-ixia.pb.txt
@@ -1,18 +1,22 @@
-name: "8000e"
+name: "cisco-ixia"
 nodes: {
-    name: "vxr1"
+    name: "vxr"
     vendor: CISCO
     model: "8201"
     os: "ios-xr"
     config: {
+        image: "ios-xr:latest" # please update the image
         file: "r1.config"
-        image: "ios-xr:latest"  # please update the image
     }
     constraints:{
         key: "memory"
         value: "20Gi"
     }
-     services:{
+   constraints:{
+        key: "memory"
+        value: "20Gi"
+    }
+    services:{
         key: 22
         value: {
             name: "ssh"
@@ -57,70 +61,74 @@ nodes: {
           name: "FourHundredGigE0/0/0/0"
         }
     }
-}
-nodes: {
-    name: "vxr2"
-    vendor: CISCO
-    model: "8201"
-    os: "ios-xr"
-    config: {
-        file: "r2.config"
-        image: "ios-xr:latest"  # please update the image
-    }
-    constraints:{
-        key: "memory"
-        value: "20Gi"
-    }
-     services:{
-        key: 22
+    interfaces: {
+        key: "eth2"
         value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 57400
-        value: {
-            name: "gnmi"
-            outside: 57400
-            inside: 57400
-        }
-    }
-   services:{
-        key: 57401
-        value: {
-            name: "gribi"
-            outside: 57401
-            inside: 57400
-        }
-    }
-   services:{
-        key: 57402
-        value: {
-            name: "gnoi"
-            outside: 57402
-            inside: 57400
-        }
-    }
-   services:{
-        key: 57403
-        value: {
-            name: "p4rt"
-            outside: 57403
-            inside: 57400
+          name: "FourHundredGigE0/0/0/1"
         }
     }
     interfaces: {
-        key: "eth1"
+        key: "eth3"
         value: {
-          name: "FourHundredGigE0/0/0/0"
+          name: "FourHundredGigE0/0/0/2"
         }
     }
-}
-links: {
-    a_node: "vxr1"
-    a_int: "eth1"
-    z_node: "vxr2"
-    z_int: "eth1"
+    interfaces: {
+        key: "eth4"
+        value: {
+          name: "FourHundredGigE0/0/0/3"
+        }
+    }
 }
 
+nodes: {
+    name: "otg"
+    vendor: KEYSIGHT
+    version: "0.0.1-3724" # Please update this with the local version from ixiatg-configmap.yaml
+    services: {
+        key: 8443
+        value: {
+            name: "https"
+            inside: 8443
+        }
+    }
+    services: {
+        key: 40051
+        value: {
+            name: "grpc"
+            inside: 40051
+        }
+    }
+    services: {
+        key: 50051
+        value: {
+            name: "gnmi"
+            inside: 50051
+        }
+    }
+}
+
+links: {
+    a_node: "otg"
+    a_int: "eth1"
+    z_node: "vxr"
+    z_int: "eth1"
+}
+links: {
+    a_node: "vxr"
+    a_int: "eth2"
+    z_node: "otg"
+    z_int: "eth2"
+}
+links: {
+    a_node: "vxr"
+    a_int: "eth3"
+    z_node: "otg"
+    z_int: "eth3"
+}
+links: {
+    a_node: "vxr"
+    a_int: "eth4"
+    z_node: "otg"
+    z_int: "eth4"
+}

--- a/examples/cisco/8000e/8000e.pb.txt
+++ b/examples/cisco/8000e/8000e.pb.txt
@@ -1,18 +1,13 @@
 name: "8000e"
 nodes: {
-    name: "vxr1"
+    name: "8000e1"
     vendor: CISCO
     model: "8201"
     os: "ios-xr"
     config: {
         file: "r1.config"
-        image: "ios-xr:latest"  # please update the image
     }
-    constraints:{
-        key: "memory"
-        value: "20Gi"
-    }
-     services:{
+   services:{
         key: 22
         value: {
             name: "ssh"
@@ -20,34 +15,34 @@ nodes: {
         }
     }
     services:{
-        key: 57400
+        key: 9339
         value: {
             name: "gnmi"
-            outside: 57400
+            outside: 9339
             inside: 57400
         }
     }
    services:{
-        key: 57401
+        key: 9340
         value: {
             name: "gribi"
-            outside: 57401
+            outside: 9340
             inside: 57400
         }
     }
    services:{
-        key: 57402
+        key: 9337
         value: {
             name: "gnoi"
-            outside: 57402
+            outside: 9337
             inside: 57400
         }
     }
    services:{
-        key: 57403
+        key: 9559
         value: {
             name: "p4rt"
-            outside: 57403
+            outside: 9559
             inside: 57400
         }
     }
@@ -59,19 +54,14 @@ nodes: {
     }
 }
 nodes: {
-    name: "vxr2"
+    name: "8000e2"
     vendor: CISCO
     model: "8201"
     os: "ios-xr"
     config: {
         file: "r2.config"
-        image: "ios-xr:latest"  # please update the image
     }
-    constraints:{
-        key: "memory"
-        value: "20Gi"
-    }
-     services:{
+  services:{
         key: 22
         value: {
             name: "ssh"
@@ -79,34 +69,34 @@ nodes: {
         }
     }
     services:{
-        key: 57400
+        key: 9339
         value: {
             name: "gnmi"
-            outside: 57400
+            outside: 9339
             inside: 57400
         }
     }
    services:{
-        key: 57401
+        key: 9340
         value: {
             name: "gribi"
-            outside: 57401
+            outside: 9340
             inside: 57400
         }
     }
    services:{
-        key: 57402
+        key: 9337
         value: {
             name: "gnoi"
-            outside: 57402
+            outside: 9337
             inside: 57400
         }
     }
    services:{
-        key: 57403
+        key: 9559
         value: {
             name: "p4rt"
-            outside: 57403
+            outside: 9559
             inside: 57400
         }
     }
@@ -118,9 +108,9 @@ nodes: {
     }
 }
 links: {
-    a_node: "vxr1"
+    a_node: "8000e1"
     a_int: "eth1"
-    z_node: "vxr2"
+    z_node: "8000e2"
     z_int: "eth1"
 }
 

--- a/examples/cisco/8000e/README.md
+++ b/examples/cisco/8000e/README.md
@@ -4,6 +4,7 @@
 
 - Ensure you have a healthy kind cluster. Please refer [setup](../../../docs/setup.md) and [topology](../../../docs/create_topology.md) documents for the detailed instructions.
 - Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`).
+- Verify if Open vSwitch is installed by running `ovs-vswitchd  --version`.
 - Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575`.
 - Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt`
 

--- a/examples/cisco/8000e/README.md
+++ b/examples/cisco/8000e/README.md
@@ -1,7 +1,7 @@
 # How to: verify and use the services on Cisco 8000e
 
 ## Check perquisites and create a kne topology using topology [8000e-ixia.pb.txt](8000e-ixia.pb.txt)
-- Ensure you have a healthy kind cluster. Please refer [here]() for the detailed instruction. 
+- Ensure you have a healthy kind cluster. Please refer [setup](../../../docs/setup.md) and [topology](../../../docs/create_topology.md) documents for the detailed instructions. 
 - Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`)
 - Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575` 
 - Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt `

--- a/examples/cisco/8000e/README.md
+++ b/examples/cisco/8000e/README.md
@@ -1,0 +1,139 @@
+# How to: verify and use the services on Cisco 8000e
+
+## Check perquisites and create a kne topology using topology [8000e-ixia.pb.txt](8000e-ixia.pb.txt)
+- Ensure you have a healthy kind cluster. Please refer [here]() for the detailed instruction. 
+- Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`)
+- Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575` 
+- Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt `
+
+The following instructions assumes that a kne cluster is created using given topology in [8000e-ixia.pb.txt](8000e-ixia.pb.txt). 
+
+## Make sure the topology is healthy
+- Make sure nodes are up and running by running command `kubectl get pods -A`. The output of the command should contain namespace `cisco-ixia` and 6 nodes with status `Running`. 4 otg ports (`otg-port-*`), one otg controller (`otg-controller`), and one cisco 8000e (`8000e`) are expected to be shown if the topology is created successfully.   
+``` 
+kubectl get pods  -A
+NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE
+cisco-ixia           8000e                                           1/1     Running   0          4m28s
+cisco-ixia           otg-controller                                  2/2     Running   0          4m28s
+cisco-ixia           otg-port-eth1                                   2/2     Running   0          4m28s
+cisco-ixia           otg-port-eth2                                   2/2     Running   0          4m28s
+cisco-ixia           otg-port-eth3                                   2/2     Running   0          4m28s
+cisco-ixia           otg-port-eth4                                   2/2     Running   0          4m27s
+-- omitted -- 
+ 
+```
+
+- Make sure external ip are mapped correctly by running command `kubectl get services -n cisco-ixia`. It is expected an external ip is assigned to each of the six nodes mentioned above.  Also, the port mapping of the gnmi/gnoi/gribi/p4rt/ssh services for 8000e should match the port mapping in the topology file.  
+``` 
+kubectl get services -n cisco-ixia
+NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                                    AGE
+service-8000e                  LoadBalancer   10.96.195.26    172.18.0.50   22:31633/TCP,9339:31543/TCP,9340:30751/TCP,9337:30331/TCP,9559:31439/TCP   7m45s
+service-gnmi-otg-controller    LoadBalancer   10.96.187.227   172.18.0.51   50051:31810/TCP                                                            7m45s
+service-grpc-otg-controller    LoadBalancer   10.96.6.73      172.18.0.52   40051:31158/TCP                                                            7m45s
+service-https-otg-controller   LoadBalancer   10.96.65.192    172.18.0.53   8443:30126/TCP                                                             7m45s
+service-otg-port-eth1          LoadBalancer   10.96.70.21     172.18.0.54   5555:30373/TCP,50071:32694/TCP                                             7m45s
+service-otg-port-eth2          LoadBalancer   10.96.166.2     172.18.0.55   5555:31205/TCP,50071:32376/TCP                                             7m45s
+service-otg-port-eth3          LoadBalancer   10.96.108.38    172.18.0.56   5555:32396/TCP,50071:30361/TCP                                             7m45s
+service-otg-port-eth4          LoadBalancer   10.96.24.228    172.18.0.57   5555:31664/TCP,50071:30416/TCP                                             7m44s
+ ```
+
+
+## Check 8000e status 
+- Based on the above output, you may use `ssh cisco@172.18.0.50` with user/pass (`cisco/cisco123`) to access cisco e8000 instance (`e8000`). 
+```
+ssh cisco@172.18.0.50 
+Password: 
+Last login: Thu Feb 23 05:03:48 2023 from 10.244.0.1
+
+RP/0/RP0/CPU0:ios#  
+```
+
+- You can also use   `kubectl exec -it -n cisco-ixia  8000e --  telnet 0 60000` to get console access to the device. 
+``` 
+ kubectl exec -it -n cisco-ixia  8000e --  telnet 0 60000
+Defaulted container "vxr" out of: vxr, init-vxr (init)
+Trying 0.0.0.0...
+Connected to 0.
+Escape character is '^]'.
+
+RP/0/RP0/CPU0:ios#
+ ```
+
+To check if the grpc is configured, you may use `show running-config grpc` after login to the router. By default grpc for 8000e is configured using tls without authentication (`insecure: false & skip_verify: true`).
+```
+RP/0/RP0/CPU0:ios#show running-config grpc
+Thu Feb 23 06:04:04.562 UTC
+grpc
+ dscp cs4
+ port 57400
+ max-streams 128
+ max-streams-per-user 128
+ address-family dual
+ max-request-total 256
+ max-request-per-user 32
+!
+RP/0/RP0/CPU0:ios#
+```
+
+## Test GNMI using external service ip and outside port
+
+``` 
+gnmic -a 172.18.0.50:9339 -u cisco -p cisco123 capabilities --skip-verify
+gNMI version: 0.8.0
+supported encodings:
+  - JSON_IETF
+  - ASCII
+  - PROTO
+supported models:
+  - openconfig-bgp-types, OpenConfig working group, 5.3.1
+  - openconfig-bgp-errors, OpenConfig working group, 5.3.1
+  -- omitted --
+
+ gnmic -a 172.18.0.50:9339 -u cisco -p cisco123 --encoding json_ietf   get --path "/system/memory" --skip-verify
+[
+  {
+    "source": "172.18.0.50:9339",
+    "timestamp": 1677133935654197129,
+    "time": "2023-02-23T06:32:15.654197129Z",
+    "updates": [
+      {
+        "Path": "openconfig:system/memory",
+        "values": {
+          "system/memory": {
+            "state": {
+              "physical": "12354125824",
+              "reserved": "0"
+            }
+          }
+        }
+      }
+    ]
+  }
+]
+ 
+```
+
+## Test gNOI service using external service ip and outside port
+
+```
+gnoic -a 172.18.0.50:9337 --skip-verify -u cisco -p cisco123 system ping --destination 44.44.44.44
+100 bytes from 44.44.44.44: icmp_seq=1 ttl=255 time=3ns
+100 bytes from 44.44.44.44: icmp_seq=2 ttl=255 time=1ns
+100 bytes from 44.44.44.44: icmp_seq=3 ttl=255 time=1ns
+100 bytes from 44.44.44.44: icmp_seq=4 ttl=255 time=1ns
+100 bytes from 44.44.44.44: icmp_seq=5 ttl=255 time=1ns
+---  ping statistics ---
+5 packets sent, 5 packets received, 0.00% packet loss
+round-trip min/avg/max/stddev = 1.000/1.000/3.000/1.000 ms
+```
+
+## Test gRIBI service using external service ip and outside port
+
+```
+gribic -a 172.18.0.50:9340 -u cisco -p cisco --skip-verify flush  --ns DEFAULT 
+INFO[0000] got 1 results                                
+INFO[0000] "172.18.0.50:9340": timestamp: 1677161921484040943
+result: OK 
+$ 
+
+```

--- a/examples/cisco/8000e/README.md
+++ b/examples/cisco/8000e/README.md
@@ -1,16 +1,19 @@
 # How to: verify and use the services on Cisco 8000e
 
 ## Check perquisites and create a kne topology using topology [8000e-ixia.pb.txt](8000e-ixia.pb.txt)
-- Ensure you have a healthy kind cluster. Please refer [setup](../../../docs/setup.md) and [topology](../../../docs/create_topology.md) documents for the detailed instructions. 
-- Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`)
-- Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575` 
-- Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt `
 
-The following instructions assumes that a kne cluster is created using given topology in [8000e-ixia.pb.txt](8000e-ixia.pb.txt). 
+- Ensure you have a healthy kind cluster. Please refer [setup](../../../docs/setup.md) and [topology](../../../docs/create_topology.md) documents for the detailed instructions.
+- Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`).
+- Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575`.
+- Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt`
+
+The following instructions assumes that a kne cluster is created using given topology in [8000e-ixia.pb.txt](8000e-ixia.pb.txt).
 
 ## Make sure the topology is healthy
-- Make sure nodes are up and running by running command `kubectl get pods -A`. The output of the command should contain namespace `cisco-ixia` and 6 nodes with status `Running`. 4 otg ports (`otg-port-*`), one otg controller (`otg-controller`), and one cisco 8000e (`8000e`) are expected to be shown if the topology is created successfully.   
-``` 
+
+- Make sure nodes are up and running by running command `kubectl get pods -A`. The output of the command should contain namespace `cisco-ixia` and 6 nodes with status `Running`. 4 otg ports (`otg-port-*`), one otg controller (`otg-controller`), and one cisco 8000e (`8000e`) are expected to be shown if the topology is created successfully.
+  
+``` bash
 kubectl get pods  -A
 NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE
 cisco-ixia           8000e                                           1/1     Running   0          4m28s
@@ -24,7 +27,8 @@ cisco-ixia           otg-port-eth4                                   2/2     Run
 ```
 
 - Make sure external ip are mapped correctly by running command `kubectl get services -n cisco-ixia`. It is expected an external ip is assigned to each of the six nodes mentioned above.  Also, the port mapping of the gnmi/gnoi/gribi/p4rt/ssh services for 8000e should match the port mapping in the topology file.  
-``` 
+  
+``` bash
 kubectl get services -n cisco-ixia
 NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                                    AGE
 service-8000e                  LoadBalancer   10.96.195.26    172.18.0.50   22:31633/TCP,9339:31543/TCP,9340:30751/TCP,9337:30331/TCP,9559:31439/TCP   7m45s
@@ -37,10 +41,11 @@ service-otg-port-eth3          LoadBalancer   10.96.108.38    172.18.0.56   5555
 service-otg-port-eth4          LoadBalancer   10.96.24.228    172.18.0.57   5555:31664/TCP,50071:30416/TCP                                             7m44s
  ```
 
+## Check 8000e status
 
-## Check 8000e status 
-- Based on the above output, you may use `ssh cisco@172.18.0.50` with user/pass (`cisco/cisco123`) to access cisco e8000 instance (`e8000`). 
-```
+- Based on the above output, you may use `ssh cisco@172.18.0.50` with user/pass (`cisco/cisco123`) to access cisco e8000 instance (`e8000`).
+
+``` bash
 ssh cisco@172.18.0.50 
 Password: 
 Last login: Thu Feb 23 05:03:48 2023 from 10.244.0.1
@@ -48,8 +53,9 @@ Last login: Thu Feb 23 05:03:48 2023 from 10.244.0.1
 RP/0/RP0/CPU0:ios#  
 ```
 
-- You can also use   `kubectl exec -it -n cisco-ixia  8000e --  telnet 0 60000` to get console access to the device. 
-``` 
+- You can also use   `kubectl exec -it -n cisco-ixia  8000e --  telnet 0 60000` to get console access to the device.
+  
+``` bash
  kubectl exec -it -n cisco-ixia  8000e --  telnet 0 60000
 Defaulted container "vxr" out of: vxr, init-vxr (init)
 Trying 0.0.0.0...
@@ -60,7 +66,8 @@ RP/0/RP0/CPU0:ios#
  ```
 
 To check if the grpc is configured, you may use `show running-config grpc` after login to the router. By default grpc for 8000e is configured using tls without authentication (`insecure: false & skip_verify: true`).
-```
+
+``` bash
 RP/0/RP0/CPU0:ios#show running-config grpc
 Thu Feb 23 06:04:04.562 UTC
 grpc
@@ -77,7 +84,7 @@ RP/0/RP0/CPU0:ios#
 
 ## Test GNMI using external service ip and outside port
 
-``` 
+``` bash
 gnmic -a 172.18.0.50:9339 -u cisco -p cisco123 capabilities --skip-verify
 gNMI version: 0.8.0
 supported encodings:
@@ -115,7 +122,7 @@ supported models:
 
 ## Test gNOI service using external service ip and outside port
 
-```
+``` bash
 gnoic -a 172.18.0.50:9337 --skip-verify -u cisco -p cisco123 system ping --destination 44.44.44.44
 100 bytes from 44.44.44.44: icmp_seq=1 ttl=255 time=3ns
 100 bytes from 44.44.44.44: icmp_seq=2 ttl=255 time=1ns
@@ -129,7 +136,7 @@ round-trip min/avg/max/stddev = 1.000/1.000/3.000/1.000 ms
 
 ## Test gRIBI service using external service ip and outside port
 
-```
+``` bash
 gribic -a 172.18.0.50:9340 -u cisco -p cisco --skip-verify flush  --ns DEFAULT 
 INFO[0000] got 1 results                                
 INFO[0000] "172.18.0.50:9340": timestamp: 1677161921484040943

--- a/examples/cisco/8000e/README.md
+++ b/examples/cisco/8000e/README.md
@@ -1,14 +1,14 @@
 # How to: verify and use the services on Cisco 8000e
 
+**Note:** The following instruction is validated on Ubuntu 20.04.1.
+
 ## Check perquisites and create a kne topology using topology [8000e-ixia.pb.txt](8000e-ixia.pb.txt)
 
 - Ensure you have a healthy kind cluster. Please refer [setup](../../../docs/setup.md) and [topology](../../../docs/create_topology.md) documents for the detailed instructions.
 - Verify if nested virtualization is configured correctly by checking presence of /dev/kvm (`ls /dev/kvm`).
-- Verify if Open vSwitch is installed by running `ovs-vswitchd  --version`.
+- Verify if Open vSwitch is installed by running `ovs-vswitchd  --version` and install  if it is missing by running `sudo apt-get install openvswitch-switch-dpdk`.
 - Set pid_max <= 1048575 using  `echo "kernel.pid_max=1048575" >> /etc/sysctl.conf` or `sysctl kernel.pid_max=1048575`.
 - Create a KNE topology using `kne create path/to/8000e-ixia.pb.txt`
-
-The following instructions assumes that a kne cluster is created using given topology in [8000e-ixia.pb.txt](8000e-ixia.pb.txt).
 
 ## Make sure the topology is healthy
 
@@ -65,6 +65,18 @@ Escape character is '^]'.
 
 RP/0/RP0/CPU0:ios#
  ```
+
+**Note:** Depending on the model, it may takes around 6 minutes for the 8000e to be fully up. You may check `startup.log` and `startup.err` using the following steps if the telnet fails:
+
+``` bash
+$ kubectl exec -it -n cisco-ixia  8000e --  bash 
+Defaulted container "8000e" out of: 8000e, init-8000e (init)
+root@8000e:/# cd /nobackup/
+root@8000e:/nobackup# ls -ltr
+-rw-r--r-- 1 root root    0 Feb 23 14:14 startup.err
+-rw-r--r-- 1 root root 4894 Feb 23 14:18 startup.log
+root@8000e:/nobackup# 
+```
 
 To check if the grpc is configured, you may use `show running-config grpc` after login to the router. By default grpc for 8000e is configured using tls without authentication (`insecure: false & skip_verify: true`).
 

--- a/examples/cisco/8000e/r1.config
+++ b/examples/cisco/8000e/r1.config
@@ -5,7 +5,11 @@ username cisco
  group root-lr
  group cisco-support
  password 7 01100F175804575D72
-! 
+!
+interface Loopback0
+ ipv4 address 44.44.44.44 255.255.255.255
+ ipv6 address 44::44/128
+!
 interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.1 255.255.255.0
 !
@@ -31,7 +35,7 @@ grpc
  max-request-total 256
  max-request-per-user 32
 !
+hw-module profile pbr vrf-redirect
+cef proactive-arp-nd enable
 ssh server vrf default
 end
-
-

--- a/examples/cisco/8000e/r2.config
+++ b/examples/cisco/8000e/r2.config
@@ -5,7 +5,11 @@ username cisco
  group root-lr
  group cisco-support
  password 7 01100F175804575D72
-! 
+!
+interface Loopback0
+ ipv4 address 44.44.44.44 255.255.255.255
+ ipv6 address 44::44/128
+!
 interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.2 255.255.255.0
 !
@@ -31,7 +35,7 @@ grpc
  max-request-total 256
  max-request-per-user 32
 !
+hw-module profile pbr vrf-redirect
+cef proactive-arp-nd enable
 ssh server vrf default
 end
-
-

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -186,7 +186,7 @@ func constraints(pb *tpb.Node) *tpb.Node {
 			pb.Constraints["cpu"] = "4"
 		}
 		if pb.Constraints["memory"] == "" {
-			pb.Constraints["memory"] = "12Gi"
+			pb.Constraints["memory"] = "20Gi"
 		}
 	default:
 		if pb.Constraints["cpu"] == "" {

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -239,7 +239,7 @@ func TestNew(t *testing.T) {
 			},
 			Constraints: map[string]string{
 				"cpu":    "4",
-				"memory": "12Gi",
+				"memory": "20Gi",
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
@@ -332,7 +332,7 @@ func TestNew(t *testing.T) {
 			},
 			Constraints: map[string]string{
 				"cpu":    "4",
-				"memory": "12Gi",
+				"memory": "20Gi",
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
@@ -432,7 +432,7 @@ func TestNew(t *testing.T) {
 			},
 			Constraints: map[string]string{
 				"cpu":    "4",
-				"memory": "12Gi",
+				"memory": "20Gi",
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
@@ -502,7 +502,7 @@ func TestNew(t *testing.T) {
 			},
 			Constraints: map[string]string{
 				"cpu":    "4",
-				"memory": "12Gi",
+				"memory": "20Gi",
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
@@ -602,7 +602,7 @@ func TestNew(t *testing.T) {
 			},
 			Constraints: map[string]string{
 				"cpu":    "4",
-				"memory": "12Gi",
+				"memory": "20Gi",
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {


### PR DESCRIPTION
This pull updates cisco 8000e topo file to included all services. This config along with existing r1 and r2 config is enough to run otg tests with cisco 8000e.