### PR TITLE
Extend timeout for image creation

### DIFF
--- a/cloudbuild/external.pkr.hcl
+++ b/cloudbuild/external.pkr.hcl
@@ -33,7 +33,7 @@ source "googlecompute" "kne-image" {
   service_account_email = "packer@gep-kne.iam.gserviceaccount.com"
   use_internal_ip       = true
   scopes                = ["https://www.googleapis.com/auth/cloud-platform"]
-  state_timeout         = "15m
+  state_timeout         = "15m"
 }
 
 build {

--- a/cloudbuild/external.pkr.hcl
+++ b/cloudbuild/external.pkr.hcl
@@ -33,6 +33,7 @@ source "googlecompute" "kne-image" {
   service_account_email = "packer@gep-kne.iam.gserviceaccount.com"
   use_internal_ip       = true
   scopes                = ["https://www.googleapis.com/auth/cloud-platform"]
+  state_timeout         = "15m
 }
 
 build {

--- a/cloudbuild/internal.pkr.hcl
+++ b/cloudbuild/internal.pkr.hcl
@@ -33,6 +33,7 @@ source "googlecompute" "kne-image" {
   service_account_email = "packer@gep-kne.iam.gserviceaccount.com"
   use_internal_ip       = true
   scopes                = ["https://www.googleapis.com/auth/cloud-platform"]
+  state_timeout         = "15m"
 }
 
 build {


### PR DESCRIPTION
https://github.com/hashicorp/packer/issues/3026

Default timeout is 5m, image creation is often taking just over 5 minutes (https://pantheon.corp.google.com/compute/operationsDetail/global/operations/operation-1675903985333-5f439cdb93526-17f46fc1-28dad892?project=gep-kne)