### PR TITLE
Fix err check in deploy

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -395,7 +395,7 @@ func (k *KindSpec) checkDependencies() error {
 func (k *KindSpec) create() error {
 	if k.Recycle {
 		log.Infof("Attempting to recycle existing cluster %q...", k.Name)
-		if err := logCommand("kubectl", "cluster-info", "--context", fmt.Sprintf("kind-%s", k.Name)); err != nil {
+		if err := logCommand("kubectl", "cluster-info", "--context", fmt.Sprintf("kind-%s", k.Name)); err == nil {
 			log.Infof("Recycling existing cluster %q", k.Name)
 			return nil
 		}


### PR DESCRIPTION
this was not caught in previous check because the --recycle option is not used in the presubmit