### PR TITLE
Increase cptx cert timeout

### DIFF
--- a/topo/node/cptx/cptx.go
+++ b/topo/node/cptx/cptx.go
@@ -31,7 +31,7 @@ var (
 	// For committing a very large config
 	scrapliOperationTimeout = 300 * time.Second
 	// Wait for PKI cert infra
-	certGenTimeout = 300 * time.Second
+	certGenTimeout = 10 * time.Minute
 )
 
 const (


### PR DESCRIPTION
Double the cert gen timeout to see if timing flake goes away