### PR TITLE
push config and generate self-signed for cisco 8000e

### DIFF
--- a/examples/cisco/8000e/r1.config
+++ b/examples/cisco/8000e/r1.config
@@ -13,19 +13,6 @@ interface Loopback0
 interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.1 255.255.255.0
 !
-! Configure BGP
-router bgp 100
- bgp router-id 10.1.1.1
- bgp update-delay 0
- address-family ipv4 unicast
-  redistribute connected
- !
- neighbor 10.1.1.2
-  remote-as 100
-  address-family ipv4 unicast
-  !
- !
-!
 grpc
  dscp cs4
  port 57400
@@ -38,4 +25,3 @@ grpc
 hw-module profile pbr vrf-redirect
 cef proactive-arp-nd enable
 ssh server vrf default
-end

--- a/examples/cisco/8000e/r1.config
+++ b/examples/cisco/8000e/r1.config
@@ -25,3 +25,5 @@ grpc
 hw-module profile pbr vrf-redirect
 cef proactive-arp-nd enable
 ssh server vrf default
+end
+commit

--- a/examples/cisco/8000e/r1.config
+++ b/examples/cisco/8000e/r1.config
@@ -26,4 +26,3 @@ hw-module profile pbr vrf-redirect
 cef proactive-arp-nd enable
 ssh server vrf default
 end
-commit

--- a/examples/cisco/8000e/r2.config
+++ b/examples/cisco/8000e/r2.config
@@ -13,19 +13,6 @@ interface Loopback0
 interface FourHundredGigE0/0/0/0
  ipv4 address 10.1.1.2 255.255.255.0
 !
-! Configure BGP
-router bgp 100
- bgp router-id 10.1.1.2
- bgp update-delay 0
- address-family ipv4 unicast
-  redistribute connected
- !
- neighbor 10.1.1.1
-  remote-as 100
-  address-family ipv4 unicast
-  !
- !
-!
 grpc
  dscp cs4
  port 57400
@@ -38,4 +25,3 @@ grpc
 hw-module profile pbr vrf-redirect
 cef proactive-arp-nd enable
 ssh server vrf default
-end

--- a/examples/cisco/8000e/r2.config
+++ b/examples/cisco/8000e/r2.config
@@ -25,3 +25,4 @@ grpc
 hw-module profile pbr vrf-redirect
 cef proactive-arp-nd enable
 ssh server vrf default
+end

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -564,6 +564,10 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 	return resp.Failed
 }
 
+func (n *Node) GenerateSelfSigned(context.Context) error {
+	return status.Errorf(codes.Unimplemented, "certificate generation is not supported")
+}
+
 func init() {
 	node.Vendor(tpb.Vendor_CISCO, New)
 }

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -520,13 +520,13 @@ func processConfig(cfg string) string {
 	lines := strings.Split(cfg, "\n")
 	lastLine := ""
 	for _, line := range lines {
-		if strings.Contains(strings.ToLower(line), "end") {
+		if strings.ToLower(strings.Trim(line, " ")) == "end" {
 			continue
 		}
 		lastLine = line
 		processedCfg = processedCfg + line + "\n"
 	}
-	if !strings.Contains(strings.ToLower(lastLine), "commit") {
+	if strings.ToLower(strings.Trim(lastLine, " ")) != "commit" {
 		processedCfg = processedCfg + "commit\n"
 	}
 	return processedCfg

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -534,7 +534,7 @@ func processConfig(cfg string) string {
 
 func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 	if n.Proto.Model == ModelXRD {
-		return status.Errorf(codes.Unimplemented, "reset config is not implemented for cisco xrd node")
+		return status.Errorf(codes.Unimplemented, "config push is not implemented for cisco xrd node")
 	}
 
 	log.Infof("%s - pushing config", n.Name())

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -565,6 +565,9 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 }
 
 func (n *Node) GenerateSelfSigned(context.Context) error {
+	// IOS XR automatically generates a self-signed certificate when gRPC is first enabled. 
+	// If the startup configuration contains a gRPC configuration, or if the user configures 
+	// gRPC after bootup, the self-signed cert will automatically be created and used.
 	return status.Errorf(codes.Unimplemented, "certificate generation is not supported")
 }
 

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -511,6 +511,33 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 	return resp.Failed
 }
 
+func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
+	log.Infof("%s - pushing config", n.Name())
+
+	cfg, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	cfgs := string(cfg)
+	log.V(1).Info(cfgs)
+
+	err = n.SpawnCLIConn()
+	if err != nil {
+		return err
+	}
+	defer n.cliConn.Close()
+
+	resp, err := n.cliConn.SendConfig(cfgs)
+	if err != nil {
+		return err
+	}
+	if resp.Failed == nil {
+		log.Infof("%s - finished config push", n.Impl.Proto.Name)
+	}
+
+	return resp.Failed
+}
+
 func init() {
 	node.Vendor(tpb.Vendor_CISCO, New)
 }

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -533,6 +533,10 @@ func processConfig(cfg string) string {
 }
 
 func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
+	if n.Proto.Model == ModelXRD {
+		return status.Errorf(codes.Unimplemented, "reset config is not implemented for cisco xrd node")
+	}
+
 	log.Infof("%s - pushing config", n.Name())
 
 	cfg, err := io.ReadAll(r)

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -524,10 +524,10 @@ func processConfig(cfg string) string {
 			continue
 		}
 		lastLine = line
-		processedCfg = processedCfg + line + "\n"
+		processedCfg += line + "\n"
 	}
 	if strings.ToLower(strings.Trim(lastLine, " ")) != "commit" {
-		processedCfg = processedCfg + "commit\n"
+		processedCfg += "commit\n"
 	}
 	return processedCfg
 }

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -565,8 +565,8 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 }
 
 func (n *Node) GenerateSelfSigned(context.Context) error {
-	// IOS XR automatically generates a self-signed certificate when gRPC is first enabled. 
-	// If the startup configuration contains a gRPC configuration, or if the user configures 
+	// IOS XR automatically generates a self-signed certificate when gRPC is first enabled.
+	// If the startup configuration contains a gRPC configuration, or if the user configures
 	// gRPC after bootup, the self-signed cert will automatically be created and used.
 	return status.Errorf(codes.Unimplemented, "certificate generation is not supported")
 }

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/h-fam/errdiff"
 	"github.com/openconfig/kne/topo/node"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -860,5 +862,14 @@ func TestPushCfg(t *testing.T) {
 				t.Fatalf("Not expecting an error, but received an error: %v \n", err)
 			}
 		})
+	}
+}
+
+func TestGenerateSelfSigned(t *testing.T) {
+	n := &Node{}
+	err := n.GenerateSelfSigned(context.Background())
+	want := codes.Unimplemented
+	if s, ok := status.FromError(err); !ok || s.Code() != want {
+		t.Fatalf("GenerateSelfSigned() unexpected error get %v, want %v", s, want)
 	}
 }

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -809,18 +809,11 @@ func TestPushCfg(t *testing.T) {
 		testConf string
 	}{
 		{
-			desc:     "successful push config for xrd",
-			wantErr:  false,
+			desc:     "unimplemented push config for xrd",
+			wantErr:  true,
 			ni:       nodeXRD,
 			testFile: "testdata/push_config_success",
 			testConf: "testdata/valid_config",
-		},
-		{
-			desc:     "failed push config for xrd",
-			wantErr:  true,
-			ni:       nodeXRD,
-			testFile: "testdata/push_config_failure",
-			testConf: "testdata/invalid_config",
 		},
 		{
 			desc:     "successful push config for 8000e",

--- a/topo/node/cisco/testdata/invalid_config
+++ b/topo/node/cisco/testdata/invalid_config
@@ -1,2 +1,1 @@
 wrongconfig
-commit

--- a/topo/node/cisco/testdata/invalid_config
+++ b/topo/node/cisco/testdata/invalid_config
@@ -1,0 +1,2 @@
+wrongconfig
+commit

--- a/topo/node/cisco/testdata/push_config_failure
+++ b/topo/node/cisco/testdata/push_config_failure
@@ -1,0 +1,15 @@
+RP/0/RP0/CPU0:ios#
+RP/0/RP0/CPU0:ios#terminal width 512
+Fri Feb 24 14:59:24.620 UTC
+RP/0/RP0/CPU0:ios#terminal length 0 
+Fri Feb 24 14:59:29.364 UTC
+RP/0/RP0/CPU0:ios#configur
+Thu May  4 20:19:25.886 UTC
+RP/0/RP0/CPU0:ios(config)#wrongconfig
+                           ^
+% Invalid input detected at '^' marker.
+RP/0/RP0/CPU0:ios(config)#commit 
+Thu May  4 20:38:26.035 UTC
+No configuration changes to commit.
+RP/0/RP0/CPU0:ios(config)#end
+RP/0/RP0/CPU0:ios#

--- a/topo/node/cisco/testdata/push_config_success
+++ b/topo/node/cisco/testdata/push_config_success
@@ -1,0 +1,23 @@
+RP/0/RP0/CPU0:ios#
+RP/0/RP0/CPU0:ios#terminal width 512
+Fri Feb 24 14:59:24.620 UTC
+RP/0/RP0/CPU0:ios#terminal length 0 
+Fri Feb 24 14:59:29.364 UTC
+RP/0/RP0/CPU0:ios#configur
+Thu May  4 20:19:25.886 UTC
+RP/0/RP0/CPU0:ios(config)#grpc
+RP/0/RP0/CPU0:ios(config-grpc)# dscp cs4
+RP/0/RP0/CPU0:ios(config-grpc)# port 57400
+RP/0/RP0/CPU0:ios(config-grpc)# max-streams 128
+RP/0/RP0/CPU0:ios(config-grpc)# max-streams-per-user 128
+RP/0/RP0/CPU0:ios(config-grpc)# address-family dual
+RP/0/RP0/CPU0:ios(config-grpc)# max-request-total 256
+RP/0/RP0/CPU0:ios(config-grpc)# max-request-per-user 32
+RP/0/RP0/CPU0:ios(config-grpc)#!
+RP/0/RP0/CPU0:ios(config-grpc)#cef proactive-arp-nd enable
+RP/0/RP0/CPU0:ios(config)#ssh server vrf default
+RP/0/RP0/CPU0:ios(config)#commit 
+Thu May  4 20:19:45.091 UTC
+RP/0/RP0/CPU0:ios(config)#end
+RP/0/RP0/CPU0:ios#
+

--- a/topo/node/cisco/testdata/valid_config
+++ b/topo/node/cisco/testdata/valid_config
@@ -7,6 +7,6 @@ grpc
  max-request-total 256
  max-request-per-user 32
 !
+end
 cef proactive-arp-nd enable
 ssh server vrf default
-commit

--- a/topo/node/cisco/testdata/valid_config
+++ b/topo/node/cisco/testdata/valid_config
@@ -1,0 +1,12 @@
+grpc
+ dscp cs4
+ port 57400
+ max-streams 128
+ max-streams-per-user 128
+ address-family dual
+ max-request-total 256
+ max-request-per-user 32
+!
+cef proactive-arp-nd enable
+ssh server vrf default
+commit


### PR DESCRIPTION
This pull adds push config for cisco devices. It also remove bgp config from default config for 8000e since these type of config needs to be loaded by tests when is needed.   Further, we change the code to return unimplemented for GenerateSelfSigned for cisco nodes. 
