### PR TITLE
Fix NPE in `kne deploy`.

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -68,10 +68,11 @@ type DeploymentConfig struct {
 // will be reported for missing files.
 func newDeployment(cfgPath string, testing bool) (*deploy.Deployment, error) {
 	c, err := load.NewConfig(cfgPath, &DeploymentConfig{})
-	c.IgnoreMissingFiles = testing
 	if err != nil {
 		return nil, err
 	}
+	c.IgnoreMissingFiles = testing
+
 	cfg := deploy.Deployment{
 		Progress: progress,
 	}


### PR DESCRIPTION
Currently, if `kne deploy` is given a file that it can't find it
will return `nil` for the configuration and the subsequent attempt
to set a field causes an NPE.
