### PR TITLE
Add more services to defaults for all vendors and update examples

### DIFF
--- a/cloudbuild/kne_test.sh
+++ b/cloudbuild/kne_test.sh
@@ -56,9 +56,9 @@ cluster:
       - us-west1-docker.pkg.dev
     containerImages:
       'us-west1-docker.pkg.dev/kne-external/kne/networkop/init-wait:ga': 'networkop/init-wait:latest'
-    config: ${HOME}/kne/kind/kind-no-cni.yaml
+    config: ${HOME}/kne/manifests/kind/config.yaml
     additionalManifests:
-      - ${HOME}/kne/manifests/kind/kind-bridge.yaml
+      - ${HOME}/kne/manifests/kind/bridge.yaml
 ingress:
   kind: MetalLB
   spec:
@@ -110,7 +110,6 @@ $cli show kne/examples/openconfig/lemming.pb.txt
 $cli topology service kne/examples/openconfig/lemming.pb.txt
 
 # Delete the topology
-
 $cli delete kne/examples/openconfig/lemming.pb.txt
 
 popd

--- a/cloudbuild/vendors/topology.textproto
+++ b/cloudbuild/vendors/topology.textproto
@@ -17,27 +17,6 @@ nodes: {
       }
     }
   }
-   services: {
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services: {
-        key: 6030
-        value: {
-            name: "gnmi"
-            inside: 6030
-        }
-    }
-    services: {
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 9340
-        }
-    }
 }
 nodes: {
   name: "cptx"
@@ -55,41 +34,6 @@ nodes: {
         key_name: "N/A"
         key_size: 4096
       }
-    }
-  }
-  services: {
-    key: 22
-    value: {
-      name: "ssh"
-      inside: 22
-    }
-  }
-  services: {
-    key: 9337
-    value: {
-      name: "gnoi"
-      inside: 32767
-    }
-  }
-  services: {
-    key: 9339
-    value: {
-      name: "gnmi"
-      inside: 32767
-    }
-  }
-  services: {
-    key: 9340
-    value: {
-      name: "gribi"
-      inside: 32767
-    }
-  }
-  services: {
-    key: 9559
-    value: {
-      name: "p4rt"
-      inside: 32767
     }
   }
   interfaces: {
@@ -144,41 +88,6 @@ nodes: {
       }
     }
   }
-  services: {
-    key: 22
-    value: {
-      name: "ssh"
-      inside: 22
-    }
-  }
-  services: {
-    key: 9337
-    value: {
-      name: "gnoi"
-      inside: 57400
-    }
-  }
-  services: {
-    key: 9339
-    value: {
-      name: "gnmi"
-      inside: 57400
-    }
-  }
-  services: {
-    key: 9340
-    value: {
-      name: "gribi"
-      inside: 57401
-    }
-  }
-  services: {
-    key: 9559
-    value: {
-      name: "p4rt"
-      inside: 9559
-    }
-  }
   interfaces: {
         key: "eth1"
         value: {
@@ -225,34 +134,6 @@ nodes: {
     image: "us-west1-docker.pkg.dev/gep-kne/cisco/xrd:ga"
     file: "cisco.cfg"
   }
-  services: {
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services: {
-        key: 9339
-        value: {
-            name: "gnmi"
-            inside: 57400
-        }
-    }
-    services: {
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 57400
-        }
-    }
-    services: {
-        key: 9337
-        value: {
-            name: "gnoi"
-            inside: 57400
-        }
-    }
     interfaces: {
         key: "eth1"
         value: {
@@ -299,34 +180,6 @@ nodes: {
     image: "us-west1-docker.pkg.dev/gep-kne/cisco/8000e:ga"
     file: "cisco.cfg"
   }
-  services: {
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services: {
-        key: 9339
-        value: {
-            name: "gnmi"
-            inside: 57400
-        }
-    }
-    services: {
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 57400
-        }
-    }
-    services: {
-        key: 9337
-        value: {
-            name: "gnoi"
-            inside: 57400
-        }
-    }
     interfaces: {
         key: "eth1"
         value: {
@@ -372,27 +225,6 @@ nodes: {
   name: "otg"
   vendor: KEYSIGHT
   version: "0.0.1-9999"
-  services: {
-    key: 443
-    value: {
-      name: "https"
-      inside: 443
-    }
-  }
-  services: {
-    key: 40051
-    value: {
-      name: "grpc"
-      inside: 40051
-    }
-  }
-  services: {
-    key: 50051
-    value: {
-      name: "gnmi"
-      inside: 50051
-    }
-  }
 }
 # Links from otg
 links: {

--- a/examples/arista/ceos-ifc/ceos-ifc.pb.txt
+++ b/examples/arista/ceos-ifc/ceos-ifc.pb.txt
@@ -3,20 +3,6 @@ nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999"
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
     interfaces: {
         key: "eth3"
         value: {

--- a/examples/arista/ceos-ipv6/ceos-ipv6.pb.txt
+++ b/examples/arista/ceos-ipv6/ceos-ipv6.pb.txt
@@ -57,20 +57,6 @@ nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999"
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
 }
 links: {
     a_node: "r1"

--- a/examples/arista/ceos-traffic/ceos-traffic.pb.txt
+++ b/examples/arista/ceos-traffic/ceos-traffic.pb.txt
@@ -57,27 +57,6 @@ nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999"
-    services: {
-        key: 443
-        value: {
-            name: "https"
-            inside: 443
-        }
-    }
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
 }
 links: {
     a_node: "r1"

--- a/examples/arista/ceos/ceos.pb.txt
+++ b/examples/arista/ceos/ceos.pb.txt
@@ -16,20 +16,6 @@ nodes: {
             }
         }
     }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 6030
-        value: {
-            name: "gnmi"
-            inside: 6030
-        }
-    }
 }
 nodes: {
     name: "r2"
@@ -46,13 +32,6 @@ nodes: {
                 key_name: "gnmiCertKey.pem",
                 key_size: 4096,
             }
-        }
-    }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
         }
     }
 }

--- a/examples/cisco/8000e/8000e-ixia.pb.txt
+++ b/examples/cisco/8000e/8000e-ixia.pb.txt
@@ -7,45 +7,6 @@ nodes: {
     config: {
         file: "r1.config"
     }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            outside: 9339
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            outside: 9340
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            outside: 9337
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            outside: 9559
-            inside: 57400
-        }
-    }
     interfaces: {
         key: "eth1"
         value: {
@@ -71,34 +32,11 @@ nodes: {
         }
     }
 }
-
 nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999" # Please update this with the local version from ixiatg-configmap.yaml
-    services: {
-        key: 8443
-        value: {
-            name: "https"
-            inside: 8443
-        }
-    }
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
 }
-
 links: {
     a_node: "8000e"
     a_int: "eth1"

--- a/examples/cisco/8000e/8000e.pb.txt
+++ b/examples/cisco/8000e/8000e.pb.txt
@@ -7,45 +7,6 @@ nodes: {
     config: {
         file: "r1.config"
     }
-   services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            outside: 9339
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            outside: 9340
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            outside: 9337
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            outside: 9559
-            inside: 57400
-        }
-    }
     interfaces: {
         key: "eth1"
         value: {
@@ -60,45 +21,6 @@ nodes: {
     os: "ios-xr"
     config: {
         file: "r2.config"
-    }
-  services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            outside: 9339
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            outside: 9340
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            outside: 9337
-            inside: 57400
-        }
-    }
-   services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            outside: 9559
-            inside: 57400
-        }
     }
     interfaces: {
         key: "eth1"

--- a/examples/cisco/xrd-traffic/xrd-traffic.pb.txt
+++ b/examples/cisco/xrd-traffic/xrd-traffic.pb.txt
@@ -51,20 +51,6 @@ nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999"
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
 }
 links: {
     a_node: "r1"

--- a/examples/cisco/xrd/xrd.pb.txt
+++ b/examples/cisco/xrd/xrd.pb.txt
@@ -14,20 +14,6 @@ nodes: {
             }
         }
     }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 57400
-        value: {
-            name: "gnmi"
-            inside: 57400
-        }
-    }
     interfaces: {
         key: "eth1"
         value: {
@@ -48,20 +34,6 @@ nodes: {
                 key_name: "r2.key",
                 key_size: 2048,
             }
-        }
-    }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 57400
-        value: {
-            name: "gnmi"
-            inside: 57400
         }
     }
     interfaces: {

--- a/examples/juniper/cptx-host/cptx-host.pb.txt
+++ b/examples/juniper/cptx-host/cptx-host.pb.txt
@@ -28,45 +28,6 @@ nodes: {
           name: "et-0/0/1"
         }
     }
-    services: {
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            outside: 9337
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            outside: 9339
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            outside: 9340
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            outside: 9559
-            inside: 32767
-        }
-    }
 }
 nodes: {
     name: "vm-1"

--- a/examples/juniper/cptx-ixia/cptx-ixia.pb.txt
+++ b/examples/juniper/cptx-ixia/cptx-ixia.pb.txt
@@ -3,27 +3,6 @@ nodes: {
     name: "otg"
     vendor: KEYSIGHT
     version: "0.0.1-9999"
-    services: {
-        key: 443
-        value: {
-            name: "ixia-c"
-            inside: 443
-        }
-    }
-    services: {
-        key: 40051
-        value: {
-            name: "grpc"
-            inside: 40051
-        }
-    }
-    services: {
-        key: 50051
-        value: {
-            name: "gnmi"
-            inside: 50051
-        }
-    }
 }
 
 nodes: {
@@ -59,45 +38,6 @@ nodes: {
         key: "eth28"
         value: {
           name: "et-0/0/3:0"
-        }
-    }
-   services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            outside: 9337
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            outside: 9339
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            outside: 9340
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            outside: 9559
-            inside: 32767
         }
     }
 }

--- a/examples/multivendor/multivendor.pb.txt
+++ b/examples/multivendor/multivendor.pb.txt
@@ -34,41 +34,6 @@ nodes: {
       }
     }
   }
-   services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 32767
-        }
-    }
-    services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            inside: 32767
-        }
-    }
   interfaces: {
     key: "eth4"
     value: {
@@ -136,41 +101,6 @@ nodes: {
   config: {
     file: "srlinux.cfg"
   }
-  services:{
-    key: 22
-    value: {
-      name: "ssh"
-      inside: 22
-    }
-  }
-  services:{
-    key: 9337
-    value: {
-      name: "gnoi"
-      inside: 57400
-    }
-  }
-  services:{
-    key: 9339
-    value: {
-      name: "gnmi"
-      inside: 57400
-    }
-  }
-  services:{
-    key: 9340
-    value: {
-      name: "gribi"
-      inside: 57401
-    }
-  }
-  services:{
-    key: 9559
-    value: {
-      name: "p4rt"
-      inside: 9559
-    }
-  }
 }
 nodes: {
   name: "xrd"
@@ -180,67 +110,11 @@ nodes: {
   config: {
     file: "xrd.cfg"
   }
-  services:{
-    key: 22
-    value: {
-      name: "ssh"
-      inside: 22
-    }
-  }
-  services:{
-    key: 9339
-    value: {
-      name: "gnmi"
-      inside: 57400
-    }
-  }
-  services:{
-    key: 9340
-    value: {
-        name: "gribi"
-        inside: 57400
-      }
-  }
-  services:{
-    key: 9337
-    value: {
-      name: "gnoi"
-      inside: 57400
-    }
-  }
-  services:{
-    key: 9559
-    value: {
-      name: "p4rt"
-      inside: 57400
-    }
-  }
 }
 nodes: {
   name: "otg"
   vendor: KEYSIGHT
   version: "0.0.1-9999"
-  services: {
-    key: 443
-    value: {
-      name: "https"
-      inside: 443
-    }
-  }
-  services: {
-    key: 40051
-    value: {
-      name: "grpc"
-      inside: 40051
-    }
-  }
-  services: {
-    key: 50051
-    value: {
-      name: "gnmi"
-      inside: 50051
-    }
-  }
 }
 # ceos - xrd
 links: {

--- a/examples/nokia/srlinux-services/2node-srl-ixr6-with-oc-services.pbtxt
+++ b/examples/nokia/srlinux-services/2node-srl-ixr6-with-oc-services.pbtxt
@@ -15,41 +15,6 @@ nodes: {
         # nodes are configured with a partial config snippet in CLI format that adds configuration relevant for this example lab.
         file: "config.cfg"
     }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            inside: 57400
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            inside: 57400
-        }
-    }
-    services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 57401
-        }
-    }
-    services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            inside: 9559
-        }
-    }
     interfaces: {
         key: "e1-1"
         value: {
@@ -65,41 +30,6 @@ nodes: {
     config:{
         # when `image` is not specified under `config`, the "ghcr.io/nokia/srlinux:latest" container image is used by default
         file: "config.cfg"
-    }
-    services:{
-        key: 22
-        value: {
-            name: "ssh"
-            inside: 22
-        }
-    }
-    services:{
-        key: 9337
-        value: {
-            name: "gnoi"
-            inside: 57400
-        }
-    }
-    services:{
-        key: 9339
-        value: {
-            name: "gnmi"
-            inside: 57400
-        }
-    }
-    services:{
-        key: 9340
-        value: {
-            name: "gribi"
-            inside: 57401
-        }
-    }
-    services:{
-        key: 9559
-        value: {
-            name: "p4rt"
-            inside: 9559
-        }
     }
     interfaces: {
         key: "e1-1"

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -355,6 +355,10 @@ func defaults(pb *tpb.Node) *tpb.Node {
 				Name:   "gnmi",
 				Inside: 6030,
 			},
+			9340: {
+				Name:   "gribi",
+				Inside: 9340,
+			},
 		}
 	}
 	if pb.Labels == nil {

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -152,6 +152,10 @@ func TestNew(t *testing.T) {
 						Name:   "gnmi",
 						Inside: 6030,
 					},
+					9340: {
+						Name:   "gribi",
+						Inside: 9340,
+					},
 				},
 			},
 		}, {
@@ -226,6 +230,10 @@ func TestNew(t *testing.T) {
 					6030: {
 						Name:   "gnmi",
 						Inside: 6030,
+					},
+					9340: {
+						Name:   "gribi",
+						Inside: 9340,
 					},
 				},
 			},

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -365,8 +365,20 @@ func defaults(pb *tpb.Node) (*tpb.Node, error) {
 				Name:   "ssh",
 				Inside: 22,
 			},
-			6030: {
+			9339: {
 				Name:   "gnmi",
+				Inside: 57400,
+			},
+			9340: {
+				Name:   "gribi",
+				Inside: 57400,
+			},
+			9337: {
+				Name:   "gnoi",
+				Inside: 57400,
+			},
+			9559: {
+				Name:   "p4rt",
 				Inside: 57400,
 			},
 		}

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -113,8 +113,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -179,8 +191,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -249,8 +273,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -338,8 +374,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -434,8 +482,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -500,8 +560,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},
@@ -596,8 +668,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				6030: {
+				9339: {
 					Name:   "gnmi",
+					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57400,
+				},
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 57400,
 				},
 			},

--- a/topo/node/cptx/cptx.go
+++ b/topo/node/cptx/cptx.go
@@ -443,8 +443,20 @@ func defaults(pb *tpb.Node) *tpb.Node {
 				Name:   "ssh",
 				Inside: 22,
 			},
-			32767: {
+			9337: {
+				Name:   "gnoi",
+				Inside: 32767,
+			},
+			9339: {
 				Name:   "gnmi",
+				Inside: 32767,
+			},
+			9340: {
+				Name:   "gribi",
+				Inside: 32767,
+			},
+			9559: {
+				Name:   "p4rt",
 				Inside: 32767,
 			},
 		}

--- a/topo/node/cptx/cptx_test.go
+++ b/topo/node/cptx/cptx_test.go
@@ -441,8 +441,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				32767: {
+				9337: {
+					Name:   "gnoi",
+					Inside: 32767,
+				},
+				9339: {
 					Name:   "gnmi",
+					Inside: 32767,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 32767,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 32767,
 				},
 			},
@@ -486,8 +498,20 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				32767: {
+				9337: {
+					Name:   "gnoi",
+					Inside: 32767,
+				},
+				9339: {
 					Name:   "gnmi",
+					Inside: 32767,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 32767,
+				},
+				9559: {
+					Name:   "p4rt",
 					Inside: 32767,
 				},
 			},

--- a/topo/node/ixia/ixia.go
+++ b/topo/node/ixia/ixia.go
@@ -323,6 +323,22 @@ func (n *Node) FixInterfaces() {
 }
 
 func defaults(pb *tpb.Node) *tpb.Node {
+	if pb.Services == nil {
+		pb.Services = map[uint32]*tpb.Service{
+			8443: {
+				Name:   "https",
+				Inside: 8443,
+			},
+			40051: {
+				Name:   "grpc",
+				Inside: 40051,
+			},
+			50051: {
+				Name:   "gnmi",
+				Inside: 50051,
+			},
+		}
+	}
 	return pb
 }
 

--- a/topo/node/ixia/ixia_test.go
+++ b/topo/node/ixia/ixia_test.go
@@ -36,6 +36,20 @@ func TestNew(t *testing.T) {
 			Config: &tpb.Config{
 				Image: "foo:bar",
 			},
+			Services: map[uint32]*tpb.Service{
+				8443: {
+					Name:   "https",
+					Inside: 8443,
+				},
+				40051: {
+					Name:   "grpc",
+					Inside: 40051,
+				},
+				50051: {
+					Name:   "gnmi",
+					Inside: 50051,
+				},
+			},
 		},
 	}}
 	for _, tt := range tests {

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -335,9 +335,21 @@ func defaults(pb *tpb.Node) *tpb.Node {
 				Name:   "ssh",
 				Inside: 22,
 			},
-			57400: {
+			9337: {
+				Name:   "gnoi",
+				Inside: 57400,
+			},
+			9339: {
 				Name:   "gnmi",
 				Inside: 57400,
+			},
+			9340: {
+				Name:   "gribi",
+				Inside: 57401,
+			},
+			9559: {
+				Name:   "p4rt",
+				Inside: 9559,
 			},
 		}
 	}

--- a/topo/node/srl/srl_test.go
+++ b/topo/node/srl/srl_test.go
@@ -121,9 +121,21 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				57400: {
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9339: {
 					Name:   "gnmi",
 					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57401,
+				},
+				9559: {
+					Name:   "p4rt",
+					Inside: 9559,
 				},
 			},
 		},
@@ -157,9 +169,21 @@ func TestNew(t *testing.T) {
 					Name:   "ssh",
 					Inside: 22,
 				},
-				57400: {
+				9337: {
+					Name:   "gnoi",
+					Inside: 57400,
+				},
+				9339: {
 					Name:   "gnmi",
 					Inside: 57400,
+				},
+				9340: {
+					Name:   "gribi",
+					Inside: 57401,
+				},
+				9559: {
+					Name:   "p4rt",
+					Inside: 9559,
 				},
 			},
 		},


### PR DESCRIPTION
This fixes issues where our example ixia topos are referencing an old port for https (443) and makes it easier for users to build topos with g* defined by default. There is no harm in exposing these services even if the device cfg cause them to not work.