### PR TITLE
Add event watching to deploy

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -281,6 +281,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 			rerr = w.Cleanup(rerr)
 		}()
 	}
+	// Watch for incoming events to fail early in case of events signaling unrecoverable errors.
 	if w, err := events.NewWatcher(ctx, kClient, cancel); err != nil {
 		log.Warningf("Failed to start event watcher: %v", err)
 	} else {


### PR DESCRIPTION
tested locally:

```
$ kne deploy ...
....
18:54:08 NS: lemming-operator Event name: lemming-controller-manager-6fc9d47f7d-tfbff.17757fb47c4a770a Type: Normal Message: Container image "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0" already present on machine
18:54:08 NS: lemming-operator Event name: lemming-controller-manager-6fc9d47f7d-tfbff.17757fb47d878ad2 Type: Normal Message: Created container kube-rbac-proxy
18:54:08 NS: lemming-operator Event name: lemming-controller-manager-6fc9d47f7d-tfbff.17757fb49ab9b5a7 Type: Normal Message: Started container kube-rbac-proxy
....
```