### PR TITLE
Add more verbose error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ func newDeleteCmd() *cobra.Command {
 		RunE:      deleteFn,
 		ValidArgs: []string{"topology"},
 	}
+	cmd.Flags().Bool("skip_wait", false, "Skips waiting for resource deletion")
 	return cmd
 }
 
@@ -169,7 +170,7 @@ func deleteFn(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", cmd.Use, err)
 	}
-	tm, err := topo.New(topopb, topo.WithKubecfg(viper.GetString("kubecfg")))
+	tm, err := topo.New(topopb, topo.WithKubecfg(viper.GetString("kubecfg")), topo.WithSkipDeleteWait(viper.GetBool("skip_wait")))
 	if err != nil {
 		return fmt.Errorf("%s: %w", cmd.Use, err)
 	}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -1181,7 +1181,6 @@ func (s *SRLinuxSpec) Deploy(ctx context.Context) error {
 	if s.Operator == "" && s.ManifestDir != "" {
 		log.Errorf("Deploying SRLinux controller using the directory 'manifests' field (%v) is deprecated, instead provide the filepath of the operator file directly using the 'operator' field going forward", s.ManifestDir)
 		s.Operator = filepath.Join(s.ManifestDir, "manifest.yaml")
-
 	}
 	log.Infof("Deploying SRLinux controller from: %s", s.Operator)
 	if err := logCommand("kubectl", "apply", "-f", s.Operator); err != nil {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -220,25 +220,25 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 		defer func() { finish(rerr) }()
 	}
 	if err := d.checkDependencies(); err != nil {
-		return err
+		return fmt.Errorf("failed to check for dependencies: %w", err)
 	}
 	log.Infof("Deploying cluster...")
 	if err := d.Cluster.Deploy(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy cluster: %w", err)
 	}
 	log.Infof("Cluster deployed")
 	if err := d.Cluster.Healthy(); err != nil {
-		return err
+		return fmt.Errorf("failed to check cluster is healthy: %w", err)
 	}
 	log.Infof("Cluster healthy")
 	// Once cluster is up, set kClient
 	rCfg, err := clientcmd.BuildConfigFromFlags("", kubecfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create k8s config: %w", err)
 	}
 	kClient, err := kubernetes.NewForConfig(rCfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create k8s client: %w", err)
 	}
 
 	log.Infof("Checking kubectl versions.")
@@ -252,11 +252,11 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 	}
 	kClientVersion, err := getVersion(kubeYAML.ClientVersion.GitVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse k8s client version: %w", err)
 	}
 	kServerVersion, err := getVersion(kubeYAML.ServerVersion.GitVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse k8s server version: %w", err)
 	}
 	origMajor := kClientVersion.Major
 	kClientVersion.Major -= 2
@@ -298,35 +298,35 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 
 	log.Infof("Deploying ingress...")
 	if err := d.Ingress.Deploy(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy ingress: %w", err)
 	}
 	tCtx, cancel := context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.Ingress.Healthy(tCtx); err != nil {
-		return err
+		return fmt.Errorf("failed to check ingress is healthy: %w", err)
 	}
 	log.Infof("Ingress healthy")
 	log.Infof("Deploying CNI...")
 	if err := d.CNI.Deploy(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy CNI: %w", err)
 	}
 	d.CNI.SetKClient(kClient)
 	tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.CNI.Healthy(tCtx); err != nil {
-		return err
+		return fmt.Errorf("failed to check CNI is healthy: %w", err)
 	}
 	log.Infof("CNI healthy")
 	for _, c := range d.Controllers {
 		log.Infof("Deploying controller...")
 		if err := c.Deploy(ctx); err != nil {
-			return err
+			return fmt.Errorf("failed to deploy controller: %w", err)
 		}
 		c.SetKClient(kClient)
 		tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 		defer cancel()
 		if err := c.Healthy(tCtx); err != nil {
-			return err
+			return fmt.Errorf("failed to check controller is healthy: %w", err)
 		}
 	}
 	log.Infof("Controllers deployed and healthy")
@@ -336,7 +336,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 func (d *Deployment) Delete() error {
 	log.Infof("Deleting cluster...")
 	if err := d.Cluster.Delete(); err != nil {
-		return err
+		return fmt.Errorf("failed to delete cluster: %w", err)
 	}
 	log.Infof("Cluster deleted")
 	return nil
@@ -344,26 +344,26 @@ func (d *Deployment) Delete() error {
 
 func (d *Deployment) Healthy(ctx context.Context) error {
 	if err := d.Cluster.Healthy(); err != nil {
-		return err
+		return fmt.Errorf("failed to check cluster is healthy: %w", err)
 	}
 	log.Infof("Cluster healthy")
 	tCtx, cancel := context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.Ingress.Healthy(tCtx); err != nil {
-		return err
+		return fmt.Errorf("failed to check ingress is healthy: %w", err)
 	}
 	log.Infof("Ingress healthy")
 	tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.CNI.Healthy(tCtx); err != nil {
-		return err
+		return fmt.Errorf("failed to check CNI is healthy: %w", err)
 	}
 	log.Infof("CNI healthy")
 	for _, c := range d.Controllers {
 		tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 		defer cancel()
 		if err := c.Healthy(tCtx); err != nil {
-			return err
+			return fmt.Errorf("failed to check controller is healthy: %w", err)
 		}
 	}
 	log.Infof("Controllers healthy")
@@ -488,7 +488,7 @@ func (k *KindSpec) checkDependencies() error {
 	if k.Version != "" {
 		wantV, err := getVersion(k.Version)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to parse desired kind version: %w", err)
 		}
 
 		stdout, err := outCommand("kind", "version")
@@ -545,8 +545,9 @@ func (k *KindSpec) create() error {
 		args = append(args, "--config", k.KindConfigFile)
 	}
 	log.Infof("Creating kind cluster with: %v", args)
+	// TODO
 	if err := logCommand("kind", args...); err != nil {
-		return fmt.Errorf("failed to create cluster: %w", err)
+		return err
 	}
 	log.Infof("Deployed kind cluster: %s", k.Name)
 	return nil
@@ -554,11 +555,11 @@ func (k *KindSpec) create() error {
 
 func (k *KindSpec) Deploy(ctx context.Context) error {
 	if err := k.checkDependencies(); err != nil {
-		return err
+		return fmt.Errorf("failed to check for dependencies: %w", err)
 	}
 
 	if err := k.create(); err != nil {
-		return err
+		return fmt.Errorf("failed to create kind cluster: %w", err)
 	}
 
 	// If the script is found, then run it. Else silently ignore it.
@@ -566,7 +567,7 @@ func (k *KindSpec) Deploy(ctx context.Context) error {
 	// be acceptable for the Cisco 8000e container.
 	if _, err := os.Stat(setPIDMaxScript); err == nil {
 		if err := logCommand(setPIDMaxScript); err != nil {
-			return err
+			return fmt.Errorf("failed to exec set_pid_max script: %w", err)
 		}
 	}
 
@@ -600,7 +601,7 @@ func (k *KindSpec) Delete() error {
 		args = append(args, "--name", k.Name)
 	}
 	if err := logCommand("kind", args...); err != nil {
-		return fmt.Errorf("failed to delete cluster using cli: %w", err)
+		return fmt.Errorf("failed to delete cluster: %w", err)
 	}
 	return nil
 }
@@ -820,13 +821,13 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 	if m.dClient == nil {
 		m.dClient, err = dclient.NewClientWithOpts(dclient.FromEnv)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create docker client: %w", err)
 		}
 	}
 	if m.mClient == nil {
 		m.mClient, err = metallbclientv1.NewForConfig(m.rCfg)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create metallb client: %w", err)
 		}
 	}
 
@@ -851,7 +852,7 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying MetalLB from: %s", m.Manifest)
 	if err := logCommand("kubectl", "apply", "-f", m.Manifest); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy metallb: %w", err)
 	}
 	if _, err := m.kClient.CoreV1().Secrets("metallb-system").Get(ctx, "memberlist", metav1.GetOptions{}); err != nil {
 		log.Infof("Creating metallb secret")
@@ -868,13 +869,13 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 			},
 		}
 		if _, err := m.kClient.CoreV1().Secrets("metallb-system").Create(ctx, s, metav1.CreateOptions{}); err != nil {
-			return err
+			return fmt.Errorf("failed to create metallb secret: %w", err)
 		}
 	}
 
 	// Wait for metallb to be healthy
 	if err := m.Healthy(ctx); err != nil {
-		return err
+		return fmt.Errorf("metallb not healthy: %w", err)
 	}
 
 	if _, err = m.mClient.IPAddressPool("metallb-system").Get(ctx, "kne-service-pool", metav1.GetOptions{}); err != nil {
@@ -882,7 +883,7 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 		// Get Network information from docker.
 		nr, err := m.dClient.NetworkList(ctx, dtypes.NetworkListOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get docker network list: %w", err)
 		}
 		var network dtypes.NetworkResource
 		for _, v := range nr {
@@ -899,7 +900,7 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 		for _, ipRange := range network.IPAM.Config {
 			_, ipNet, err := net.ParseCIDR(ipRange.Subnet)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse cidr: %w", err)
 			}
 			if ipNet.IP.To4() != nil {
 				n = ipNet
@@ -932,7 +933,7 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 			},
 		}
 		if _, err = m.mClient.L2Advertisement("metallb-system").Create(ctx, l2Advert, metav1.CreateOptions{}); err != nil {
-			return err
+			return fmt.Errorf("failed to create metallb L2 advertisement: %w", err)
 		}
 	}
 	return nil
@@ -981,7 +982,7 @@ func (m *MeshnetSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying Meshnet from: %s", m.Manifest)
 	if err := logCommand("kubectl", "apply", "-f", m.Manifest); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy meshnet: %w", err)
 	}
 	log.Infof("Meshnet Deployed")
 	return nil
@@ -998,10 +999,10 @@ func (m *MeshnetSpec) Healthy(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context canceled before healthy")
+			return fmt.Errorf("context canceled before meshnet healthy")
 		case e, ok := <-w.ResultChan():
 			if !ok {
-				return fmt.Errorf("watch channel closed before healthy")
+				return fmt.Errorf("watch channel closed before meshnet healthy")
 			}
 			d, ok := e.Object.(*appsv1.DaemonSet)
 			if !ok {
@@ -1055,7 +1056,7 @@ func (c *CEOSLabSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying CEOSLab controller from: %s", c.Operator)
 	if err := logCommand("kubectl", "apply", "-f", c.Operator); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy ceoslab operator: %w", err)
 	}
 	log.Infof("CEOSLab controller deployed")
 	return nil
@@ -1104,7 +1105,7 @@ func (l *LemmingSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying Lemming controller from: %s", l.Operator)
 	if err := logCommand("kubectl", "apply", "-f", l.Operator); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy lemming operator: %w", err)
 	}
 	log.Infof("Lemming controller deployed")
 	return nil
@@ -1153,7 +1154,7 @@ func (s *SRLinuxSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying SRLinux controller from: %s", s.Operator)
 	if err := logCommand("kubectl", "apply", "-f", s.Operator); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy srlinux operator: %w", err)
 	}
 	log.Infof("SRLinux controller deployed")
 	return nil
@@ -1204,7 +1205,7 @@ func (i *IxiaTGSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying IxiaTG controller from: %s", i.Operator)
 	if err := logCommand("kubectl", "apply", "-f", i.Operator); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy ixiatg operator: %w", err)
 	}
 
 	if i.ConfigMap == "" && i.ManifestDir != "" {
@@ -1238,7 +1239,7 @@ func (i *IxiaTGSpec) Deploy(ctx context.Context) error {
 	}
 	log.Infof("Deploying IxiaTG config map from: %s", i.ConfigMap)
 	if err := logCommand("kubectl", "apply", "-f", i.ConfigMap); err != nil {
-		return err
+		return fmt.Errorf("failed to deploy ixiatg config map: %w", err)
 	}
 	log.Infof("IxiaTG controller deployed")
 	return nil
@@ -1252,16 +1253,16 @@ func deploymentHealthy(ctx context.Context, c kubernetes.Interface, name string)
 	log.Infof("Waiting on deployment %q to be healthy", name)
 	w, err := c.AppsV1().Deployments(name).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create watcher for deployment %q", name)
 	}
 	ch := w.ResultChan()
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context canceled before healthy")
+			return fmt.Errorf("context canceled before %q healthy", name)
 		case e, ok := <-ch:
 			if !ok {
-				return fmt.Errorf("watch channel closed before healthy")
+				return fmt.Errorf("watch channel closed before %q healthy", name)
 			}
 			d, ok := e.Object.(*appsv1.Deployment)
 			if !ok {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -251,7 +251,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 	}
 	log.Infof("Cluster deployed")
 	if err := d.Cluster.Healthy(); err != nil {
-		return fmt.Errorf("failed to check cluster is healthy: %w", err)
+		return fmt.Errorf("failed to check if cluster is healthy: %w", err)
 	}
 	log.Infof("Cluster healthy")
 	// Once cluster is up, set kClient
@@ -326,7 +326,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 	tCtx, cancel := context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.Ingress.Healthy(tCtx); err != nil {
-		return fmt.Errorf("failed to check ingress is healthy: %w", err)
+		return fmt.Errorf("failed to check if ingress is healthy: %w", err)
 	}
 	log.Infof("Ingress healthy")
 	log.Infof("Deploying CNI...")
@@ -337,7 +337,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 	tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	if err := d.CNI.Healthy(tCtx); err != nil {
-		return fmt.Errorf("failed to check CNI is healthy: %w", err)
+		return fmt.Errorf("failed to check if CNI is healthy: %w", err)
 	}
 	log.Infof("CNI healthy")
 	for _, c := range d.Controllers {
@@ -349,7 +349,7 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 		tCtx, cancel = context.WithTimeout(ctx, healthTimeout)
 		defer cancel()
 		if err := c.Healthy(tCtx); err != nil {
-			return fmt.Errorf("failed to check controller is healthy: %w", err)
+			return fmt.Errorf("failed to check if controller is healthy: %w", err)
 		}
 	}
 	log.Infof("Controllers deployed and healthy")

--- a/topo/node/node.go
+++ b/topo/node/node.go
@@ -32,6 +32,7 @@ type Interface interface {
 	Name() string
 	GetNamespace() string
 	GetProto() *tpb.Node
+	String() string
 }
 
 type Implementation interface {
@@ -138,6 +139,10 @@ func (n *Impl) GetProto() *tpb.Node {
 
 func (n *Impl) GetNamespace() string {
 	return n.Namespace
+}
+
+func (n *Impl) String() string {
+	return fmt.Sprintf("%q (vendor: %q, model: %q)", n.Proto.Name, n.Proto.Vendor, n.Proto.Model)
 }
 
 func (n *Impl) TopologySpecs(context.Context) ([]*topologyv1.Topology, error) {

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -308,6 +308,7 @@ func (m *Manager) Delete(ctx context.Context) error {
 	}
 	if !m.skipDeleteWait {
 		// Wait for namespace deletion.
+		log.Infof("Waiting for namespace %q to be deleted", m.topo.Name)
 		defer close(c)
 		if err := <-c; err != nil {
 			return fmt.Errorf("failed to wait for namespace %q deletion: %w", m.topo.Name, err)
@@ -324,7 +325,6 @@ func waitNSDeleted(ctx context.Context, kClient kubernetes.Interface, ns string,
 		errCh <- err
 		return
 	}
-	log.Infof("Waiting for namespace %q to be deleted", ns)
 	for {
 		select {
 		case <-ctx.Done():

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -590,7 +590,7 @@ func (m *Manager) createMeshnetTopologies(ctx context.Context) error {
 func (m *Manager) deleteMeshnetTopologies(ctx context.Context) error {
 	nodes, err := m.topologyResources(ctx)
 	if err != nil {
-		fmt.Errorf("failed to get meshnet nodes: %w", err)
+		return fmt.Errorf("failed to get meshnet nodes: %w", err)
 	}
 	var errs errlist.List
 	for _, n := range nodes {

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -502,7 +502,7 @@ func TestCreate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: `Node "bad": Status FAILED`,
+		wantErr: `Node "bad" (vendor: "1002", model: ""): Status FAILED`,
 	}, {
 		desc: "failed to report metrics, create still passes",
 		opts: []Option{WithUsageReporting(true, "", "")},

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	ktest "k8s.io/client-go/testing"
@@ -586,14 +587,65 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+type fakeWatch struct {
+	ch   chan watch.Event
+	done chan struct{}
+}
+
+func (f *fakeWatch) Stop() {
+	close(f.done)
+}
+
+func (f *fakeWatch) ResultChan() <-chan watch.Event {
+	return f.ch
+}
+
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
 	node.Vendor(tpb.Vendor(1003), NewConfigurable)
+
+	failWatchEvents := []watch.Event{
+		watch.Event{
+			Type: watch.Deleted,
+			Object: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dne",
+				},
+			},
+		},
+		watch.Event{
+			Type: watch.Added,
+			Object: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+		},
+	}
+	passWatchEvents := append(failWatchEvents,
+		watch.Event{
+			Type: watch.Deleted,
+			Object: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+		},
+	)
+
+	origDeleteWatchTimeout := deleteWatchTimeout
+	defer func() {
+		deleteWatchTimeout = origDeleteWatchTimeout
+	}()
+	deleteWatchTimeout = time.Millisecond
+
 	tests := []struct {
-		desc       string
-		topo       *tpb.Topology
-		k8sObjects []runtime.Object
-		wantErr    string
+		desc        string
+		topo        *tpb.Topology
+		k8sObjects  []runtime.Object
+		skipWait    bool
+		watchEvents []watch.Event
+		wantErr     string
 	}{{
 		desc: "delete a non-existent topo",
 		topo: &tpb.Topology{
@@ -630,7 +682,8 @@ func TestDelete(t *testing.T) {
 				},
 			},
 		},
-		wantErr: "does not exist in cluster",
+		skipWait: true,
+		wantErr:  "does not exist in cluster",
 	}, {
 		desc: "delete an existing topo",
 		topo: &tpb.Topology{
@@ -680,6 +733,159 @@ func TestDelete(t *testing.T) {
 				},
 			},
 		},
+		skipWait: true,
+	}, {
+		desc: "delete with watch",
+		topo: &tpb.Topology{
+			Name: "test",
+			Nodes: []*tpb.Node{
+				{
+					Name:   "r1",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						1000: {
+							Name: "ssh",
+						},
+					},
+				},
+				{
+					Name:   "r2",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						2000: {
+							Name: "grpc",
+						},
+						3000: {
+							Name: "gnmi",
+						},
+					},
+				},
+			},
+			Links: []*tpb.Link{
+				{
+					ANode: "r1",
+					AInt:  "eth1",
+					ZNode: "r2",
+					ZInt:  "eth1",
+				},
+			},
+		},
+		k8sObjects: []runtime.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "r1",
+					Namespace: "test",
+				},
+			},
+		},
+		watchEvents: passWatchEvents,
+	}, {
+		desc: "delete with watch - bad events",
+		topo: &tpb.Topology{
+			Name: "test",
+			Nodes: []*tpb.Node{
+				{
+					Name:   "r1",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						1000: {
+							Name: "ssh",
+						},
+					},
+				},
+				{
+					Name:   "r2",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						2000: {
+							Name: "grpc",
+						},
+						3000: {
+							Name: "gnmi",
+						},
+					},
+				},
+			},
+			Links: []*tpb.Link{
+				{
+					ANode: "r1",
+					AInt:  "eth1",
+					ZNode: "r2",
+					ZInt:  "eth1",
+				},
+			},
+		},
+		k8sObjects: []runtime.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "r1",
+					Namespace: "test",
+				},
+			},
+		},
+		watchEvents: failWatchEvents,
+		wantErr:     "context canceled before namespace deleted",
+	}, {
+		desc: "delete without watch - bad events",
+		topo: &tpb.Topology{
+			Name: "test",
+			Nodes: []*tpb.Node{
+				{
+					Name:   "r1",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						1000: {
+							Name: "ssh",
+						},
+					},
+				},
+				{
+					Name:   "r2",
+					Vendor: tpb.Vendor(1003),
+					Services: map[uint32]*tpb.Service{
+						2000: {
+							Name: "grpc",
+						},
+						3000: {
+							Name: "gnmi",
+						},
+					},
+				},
+			},
+			Links: []*tpb.Link{
+				{
+					ANode: "r1",
+					AInt:  "eth1",
+					ZNode: "r2",
+					ZInt:  "eth1",
+				},
+			},
+		},
+		k8sObjects: []runtime.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "r1",
+					Namespace: "test",
+				},
+			},
+		},
+		skipWait:    true,
+		watchEvents: failWatchEvents,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -687,10 +893,28 @@ func TestDelete(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot create fake topology clientset: %v", err)
 			}
+			kf := kfake.NewSimpleClientset(tt.k8sObjects...)
+			kf.PrependWatchReactor("*", func(action ktest.Action) (bool, watch.Interface, error) {
+				f := &fakeWatch{
+					ch:   make(chan watch.Event, 1),
+					done: make(chan struct{}),
+				}
+				go func() {
+					for _, e := range tt.watchEvents {
+						select {
+						case f.ch <- e:
+						case <-f.done:
+							return
+						}
+					}
+				}()
+				return true, f, nil
+			})
 			opts := []Option{
 				WithClusterConfig(&rest.Config{}),
-				WithKubeClient(kfake.NewSimpleClientset(tt.k8sObjects...)),
+				WithKubeClient(kf),
 				WithTopoClient(tf),
+				WithSkipDeleteWait(tt.skipWait),
 			}
 			m, err := New(tt.topo, opts...)
 			if err != nil {

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -605,7 +605,7 @@ func TestDelete(t *testing.T) {
 	node.Vendor(tpb.Vendor(1003), NewConfigurable)
 
 	failWatchEvents := []watch.Event{
-		watch.Event{
+		{
 			Type: watch.Deleted,
 			Object: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -613,7 +613,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 		},
-		watch.Event{
+		{
 			Type: watch.Added,
 			Object: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Also add watching for namespace deletion to avoid cases errors such as:

```
$ ./kne_cli create ../examples/openconfig/lemming.pb.txt
I0802 19:08:06.480612  630769 root.go:143] /usr/local/google/home/alexmasi/kne/examples/openconfig
I0802 19:08:06.482492  630769 topo.go:161] Trying in-cluster configuration
I0802 19:08:06.482515  630769 topo.go:164] Falling back to kubeconfig: "/usr/local/google/home/alexmasi/.kube/config"
I0802 19:08:06.483907  630769 topo.go:421] Adding Link: lemming1:eth1 lemming2:eth1
I0802 19:08:06.483929  630769 topo.go:462] Adding Node: lemming1:OPENCONFIG
I0802 19:08:06.483951  630769 topo.go:462] Adding Node: lemming2:OPENCONFIG
Error: failed to create topology "lemming-twodut": failed to create meshnet topologies: could not create topology for meshnet node lemming1: topologies.networkop.co.uk "lemming1" is forbidden: unable to create new content in namespace lemming-twodut because it is being terminated
```

when using `kne create` right after `kne delete`