### PR TITLE
juniper config mode retry and error handling

### DIFF
--- a/topo/node/juniper/juniper.go
+++ b/topo/node/juniper/juniper.go
@@ -115,7 +115,6 @@ func (n *Node) GRPCConfig() []string {
 
 // Waits and retries until CLI config mode is up and config is applied
 func (n *Node) waitConfigInfraReadyAndPushConfigs(configs []string) error {
-
 	log.Infof("Waiting for config to be pushed (timeout: %v) node %s", configModeTimeout, n.Name())
 	start := time.Now()
 	for time.Since(start) < configModeTimeout {

--- a/topo/node/juniper/juniper.go
+++ b/topo/node/juniper/juniper.go
@@ -35,6 +35,10 @@ var (
 	certGenTimeout = 10 * time.Minute
 	// Time between polls
 	certGenRetrySleep = 30 * time.Second
+	// Wait for config mode
+	configModeTimeout = 10 * time.Minute
+	// Time between polls - config mode
+	configModeRetrySleep = 30 * time.Second
 )
 
 const (
@@ -109,6 +113,39 @@ func (n *Node) GRPCConfig() []string {
 	}
 }
 
+// Waits and retries until CLI config mode is up and config is applied
+func (n *Node) waitConfigInfraReadyAndPushConfigs(configs []string) error {
+
+	log.Infof("Waiting for config to be pushed (timeout: %v) node %s", configModeTimeout, n.Name())
+	start := time.Now()
+	for time.Since(start) < configModeTimeout {
+		multiresp, err := n.cliConn.SendConfigs(configs)
+		if err != nil {
+			if strings.Contains(err.Error(), "errPrivilegeError") {
+				log.Infof("Config mode not ready. Retrying in %v. Node %s, Resp %v", configModeRetrySleep, n.Name(), err)
+			} else {
+				return fmt.Errorf("failed pushing configs: %v", err)
+			}
+		} else {
+			for _, resp := range multiresp.Responses {
+				if resp.Failed != nil {
+					return resp.Failed
+				}
+				if strings.Contains(resp.Result, "commit complete") {
+					log.Infof("Config mode ready. Config commit done. Node %s", n.Name())
+					return nil
+				}
+				if strings.Contains(resp.Result, "error:") {
+					log.Infof("Config mode not ready. Retrying in %v. Node %s Response %s", certGenRetrySleep, n.Name(), multiresp.JoinedResult())
+				}
+			}
+		}
+		time.Sleep(configModeRetrySleep)
+	}
+
+	return fmt.Errorf("failed sending configs")
+}
+
 // Waits and retries until Cert infra is up and certs are applied
 func (n *Node) waitCertInfraReadyAndPushCert() error {
 	selfSigned := n.Proto.GetConfig().GetCert().GetSelfSigned()
@@ -119,7 +156,7 @@ func (n *Node) waitCertInfraReadyAndPushCert() error {
 			selfSigned.GetCertName()),
 	}
 
-	log.Infof("Waiting for certificates to be pushed (timeout: %v)", certGenTimeout)
+	log.Infof("Waiting for certificates to be pushed (timeout: %v) node %s", certGenTimeout, n.Name())
 	start := time.Now()
 	for time.Since(start) < certGenTimeout {
 		multiresp, err := n.cliConn.SendCommands(commands)
@@ -130,12 +167,12 @@ func (n *Node) waitCertInfraReadyAndPushCert() error {
 			if resp.Failed != nil {
 				return resp.Failed
 			}
-			if strings.Contains(resp.Result, "error:") {
-				log.Infof("Cert infra isn't ready. Retrying in %v. Response %s", certGenRetrySleep, multiresp.JoinedResult())
-			}
 			if strings.Contains(resp.Result, "successfully") {
-				log.Infof("Cert Infra ready. Configured Certs. Response %s", multiresp.JoinedResult())
+				log.Infof("Cert Infra ready. Configured Certs. Node %s, Response %s", n.Name(), multiresp.JoinedResult())
 				return nil
+			}
+			if strings.Contains(resp.Result, "error:") {
+				log.Infof("Cert infra isn't ready. Retrying in %v. Node %s Response %s", certGenRetrySleep, n.Name(), multiresp.JoinedResult())
 			}
 		}
 		time.Sleep(certGenRetrySleep)
@@ -186,13 +223,8 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 	}
 
 	// Send gRPC config
-	resp, err := n.cliConn.SendConfigs(n.GRPCConfig())
-	if err != nil {
-		return err
-	}
-
-	if resp.Failed != nil {
-		return resp.Failed
+	if err := n.waitConfigInfraReadyAndPushConfigs(n.GRPCConfig()); err != nil {
+		return fmt.Errorf("failed sending grpc config commands - self-signed-cert: %v", err)
 	}
 
 	log.Infof("%s - finished cert generation", n.Name())
@@ -379,11 +411,6 @@ func (n *Node) Create(ctx context.Context) error {
 						MountPath: "/tmp",
 					},
 					{
-						Name:      fmt.Sprintf("%s-sys-class-mount", pb.Name),
-						ReadOnly:  false,
-						MountPath: "/sys/class",
-					},
-					{
 						Name:      fmt.Sprintf("%s-dev-shm-mount", pb.Name),
 						ReadOnly:  false,
 						MountPath: "/dev/shm",
@@ -409,15 +436,6 @@ func (n *Node) Create(ctx context.Context) error {
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium: "Memory",
-						},
-					},
-				},
-				{
-					Name: fmt.Sprintf("%s-sys-class-mount", pb.Name),
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/sys/class",
-							Type: &hpd,
 						},
 					},
 				},

--- a/topo/node/juniper/juniper_test.go
+++ b/topo/node/juniper/juniper_test.go
@@ -136,6 +136,12 @@ func TestGenerateSelfSigned(t *testing.T) {
 	}()
 	certGenRetrySleep = time.Millisecond
 
+	origConfigModeRetrySleep := configModeRetrySleep
+	defer func() {
+		configModeRetrySleep = origConfigModeRetrySleep
+	}()
+	configModeRetrySleep = time.Millisecond
+
 	tests := []struct {
 		desc     string
 		wantErr  bool

--- a/topo/node/juniper/juniper_test.go
+++ b/topo/node/juniper/juniper_test.go
@@ -156,6 +156,20 @@ func TestGenerateSelfSigned(t *testing.T) {
 			ni:       ni,
 			testFile: "testdata/generate_certificate_failure",
 		},
+		{
+			// device returns config mode error but we eventually recover
+			desc:     "success config mode",
+			wantErr:  false,
+			ni:       ni,
+			testFile: "testdata/generate_certificate_config_mode_success",
+		},
+		{
+			// device returns "Error: something bad happened" -- we expect to fail
+			desc:     "failure config commit",
+			wantErr:  true,
+			ni:       ni,
+			testFile: "testdata/generate_certificate_config_mode_failure",
+		},
 	}
 
 	for _, tt := range tests {

--- a/topo/node/juniper/testdata/generate_certificate_config_mode_failure
+++ b/topo/node/juniper/testdata/generate_certificate_config_mode_failure
@@ -1,0 +1,72 @@
+root@cptx2>
+
+root@cptx2> set cli screen-width 511
+Screen width set to 511
+
+root@cptx2> set cli screen-length 0
+Screen length set to 0
+
+root@cptx2> set cli complete-on-space off
+Disabling complete-on-space
+
+root@cptx2> request security pki generate-key-pair certificate-id grpc-server-cert
+Generated key pair grpc-server-cert, key size 2048 bits
+
+root@cptx2> request security pki local-certificate generate-self-signed certificate-id grpc-server-cert subject CN=abc domain-name google.com ip-address 1.2.3.4 email example@google.com
+Self-signed certificate generated and loaded successfully
+
+root@cptx2>
+root@cptx2>exit
+
+root@cptx2>
+
+root@cptx2> configure
+error: unknown command: configure
+Configuration is allowed only from the Routing Engine with GlobalIPOwner attribute assigned. Please check "show system nodes" command output.
+root@cptx2>
+root@cptx2> configure
+Entering configuration mode
+
+[edit]
+root@cptx2#
+root@cptx2# set system services extension-service request-response grpc ssl hot-reloading
+
+[edit]
+root@cptx2#
+root@cptx2# set system services extension-service request-response grpc ssl use-pki
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config services GNMI
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config enable true
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config port 32767
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config transport-security true
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config certificate-id grpc-server-cert
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config listen-addresses 0.0.0.0
+
+[edit]
+root@cptx2#
+root@cptx2# commit
+commit error
+
+[edit]
+root@cptx2#
+root@cptx2# exit configuration-mode
+Exiting configuration mode
+
+root@cptx2> exit

--- a/topo/node/juniper/testdata/generate_certificate_config_mode_success
+++ b/topo/node/juniper/testdata/generate_certificate_config_mode_success
@@ -1,0 +1,72 @@
+root@cptx2>
+
+root@cptx2> set cli screen-width 511
+Screen width set to 511
+
+root@cptx2> set cli screen-length 0
+Screen length set to 0
+
+root@cptx2> set cli complete-on-space off
+Disabling complete-on-space
+
+root@cptx2> request security pki generate-key-pair certificate-id grpc-server-cert
+Generated key pair grpc-server-cert, key size 2048 bits
+
+root@cptx2> request security pki local-certificate generate-self-signed certificate-id grpc-server-cert subject CN=abc domain-name google.com ip-address 1.2.3.4 email example@google.com
+Self-signed certificate generated and loaded successfully
+
+root@cptx2>
+root@cptx2>exit
+
+root@cptx2>
+
+root@cptx2> configure
+error: unknown command: configure
+Configuration is allowed only from the Routing Engine with GlobalIPOwner attribute assigned. Please check "show system nodes" command output.
+root@cptx2>
+root@cptx2> configure
+Entering configuration mode
+
+[edit]
+root@cptx2#
+root@cptx2# set system services extension-service request-response grpc ssl hot-reloading
+
+[edit]
+root@cptx2#
+root@cptx2# set system services extension-service request-response grpc ssl use-pki
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config services GNMI
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config enable true
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config port 32767
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config transport-security true
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config certificate-id grpc-server-cert
+
+[edit]
+root@cptx2#
+root@cptx2# set openconfig-system:system openconfig-system-grpc:grpc-servers grpc-server grpc-server config listen-addresses 0.0.0.0
+
+[edit]
+root@cptx2#
+root@cptx2# commit
+commit complete
+
+[edit]
+root@cptx2#
+root@cptx2# exit configuration-mode
+Exiting configuration mode
+
+root@cptx2> exit


### PR DESCRIPTION
In rare occasions, getting into config mode can take some time. Change here adds retry in case of privilege error by Scrapligo. Scrapligo throws this when config mode is not yet available. Also adds a bit better error handling and printing pod information when certificate push failure occurs.

Also gets rid of /sys/class mount which is no longer needed.