### PR TITLE
Enable the admission webhook

### DIFF
--- a/topo/topo.go
+++ b/topo/topo.go
@@ -543,6 +543,9 @@ func (m *Manager) push(ctx context.Context) error {
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: m.topo.Name,
+				Labels: map[string]string{
+					"admission-webhook": "enabled",
+				},
 			},
 		}
 		sNs, err := m.kClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -544,7 +544,7 @@ func (m *Manager) push(ctx context.Context) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: m.topo.Name,
 				Labels: map[string]string{
-					"admission-webhook": "enabled",
+					"kne-topology": "true",
 				},
 			},
 		}


### PR DESCRIPTION
This enables the admission webhook on kne created namespace allowing the said webhook to manipulate pod specs.