### PR TITLE
After deleting a topology, remove it from the map.

### DIFF
--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -418,6 +418,7 @@ func (s *server) DeleteTopology(ctx context.Context, req *cpb.DeleteTopologyRequ
 	if err := tm.Delete(ctx); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete topology: %v", err)
 	}
+	delete(s.topos, req.GetTopologyName())
 	return &cpb.DeleteTopologyResponse{}, nil
 }
 


### PR DESCRIPTION
DeleteTopology was not removing the topology from s.topos preventing the topology from being re-deployed after deleting the existing deployment.