### PR TITLE
Fix file perm for kubecfg creation when using kubeadm

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -459,7 +459,7 @@ func (k *KubeadmSpec) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(kubeDir, "config"), b, 0640); err != nil {
+	if err := os.WriteFile(filepath.Join(kubeDir, "config"), b, 0600); err != nil {
 		return err
 	}
 	if k.AllowControlPlaneScheduling {


### PR DESCRIPTION
This was not a critical change but it more closely matches the file perms by default and satisfies the linter.