### PR TITLE
Fix cluster names

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -393,7 +393,7 @@ func (e *ExternalSpec) Healthy() error {
 }
 
 func (e *ExternalSpec) GetName() string {
-	return "external"
+	return "kne"
 }
 
 func (e *ExternalSpec) GetDockerNetworkResourceName() string {
@@ -523,7 +523,7 @@ func (k *KubeadmSpec) Healthy() error {
 }
 
 func (k *KubeadmSpec) GetName() string {
-	return "kubeadm"
+	return "kne"
 }
 
 func (k *KubeadmSpec) GetDockerNetworkResourceName() string {
@@ -705,7 +705,7 @@ func (k *KindSpec) GetName() string {
 	if k.Name != "" {
 		return k.Name
 	}
-	return "kind"
+	return "kne"
 }
 
 func (k *KindSpec) GetDockerNetworkResourceName() string {


### PR DESCRIPTION
The topology manager expects these to be "kne". These are otherwise unused so safe to change defaults.