### PR TITLE
Add handling for cri-docker

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -46,6 +46,7 @@ var (
 	pullRetryDelay  = time.Second
 	poolRetryDelay  = 5 * time.Second
 	healthTimeout   = time.Minute
+	criDocker       = "cri-docker"
 
 	// Stubs for testing.
 	execLookPath       = exec.LookPath
@@ -445,6 +446,15 @@ func (k *KubeadmSpec) Deploy(ctx context.Context) error {
 	args := []string{"kubeadm", "init"}
 	if k.CRISocket != "" {
 		args = append(args, "--cri-socket", k.CRISocket)
+		// If using cri-docker, then ensure the components are running.
+		if strings.Contains(k.CRISocket, criDocker) {
+			if err := run.LogCommand("sudo", "systemctl", "enable", "--now", criDocker+".socket"); err != nil {
+				return err
+			}
+			if err := run.LogCommand("sudo", "systemctl", "enable", "--now", criDocker+".service"); err != nil {
+				return err
+			}
+		}
 	}
 	if k.PodNetworkCIDR != "" {
 		args = append(args, "--pod-network-cidr", k.PodNetworkCIDR)

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -465,10 +465,10 @@ func (k *KubeadmSpec) Deploy(ctx context.Context) error {
 	log.Infof("Creating kubeadm cluster with: %v", args)
 	if out, err := run.OutLogCommand("sudo", args...); err != nil {
 		msg := []string{}
-		// Filter output to only show lines relevant to the error message. For kind these are lines
-		// prefixed with "ERROR" or "Command Output".
+		// Filter output to only show lines relevant to the error message. For kubeadm these are lines
+		// containing "error" in any case.
 		for _, line := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(line, "ERROR") || strings.HasPrefix(line, "Command Output") {
+			if strings.Contains(strings.ToLower(line), "error") {
 				msg = append(msg, line)
 			}
 		}

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -65,6 +65,18 @@ func TestKubeadmSpec(t *testing.T) {
 			{Cmd: "docker", Args: []string{"network", "create", "kne-kubeadm-.*"}},
 		},
 	}, {
+		desc: "use cri-docker",
+		k: &KubeadmSpec{
+			CRISocket: "unix:///var/run/cri-dockerd.sock",
+		},
+		resp: []fexec.Response{
+			{Cmd: "sudo", Args: []string{"systemctl", "enable", "--now", "cri-docker.socket"}},
+			{Cmd: "sudo", Args: []string{"systemctl", "enable", "--now", "cri-docker.service"}},
+			{Cmd: "sudo", Args: []string{"kubeadm", "init", "--cri-socket", "unix:///var/run/cri-dockerd.sock"}},
+			{Cmd: "sudo", Args: []string{"cat", "/etc/kubernetes/admin.conf"}},
+			{Cmd: "docker", Args: []string{"network", "create", "kne-kubeadm-.*"}},
+		},
+	}, {
 		desc: "allow control plane scheduling",
 		k: &KubeadmSpec{
 			AllowControlPlaneScheduling: true,


### PR DESCRIPTION
Often times the cri-docker components are not running as expected during the preflight checks for kubeadm init. This handler ensures that they are running before proceeding to kubeadm init.