### PR TITLE
Increase max instances to accommodate large scale cisco xrd topos

### DIFF
--- a/cloudbuild/external.pkr.hcl
+++ b/cloudbuild/external.pkr.hcl
@@ -73,7 +73,7 @@ build {
       "sudo usermod -aG docker $USER",
       "sudo docker version",
       "sudo apt-get install openvswitch-switch-dpdk -y",   # install openvswitch for cisco containers
-      "echo \"fs.inotify.max_user_instances=64000\" | sudo tee -a /etc/sysctl.conf", # configure inotify for cisco xrd containers
+      "echo \"fs.inotify.max_user_instances=128000\" | sudo tee -a /etc/sysctl.conf", # configure inotify for cisco xrd containers
       "echo \"kernel.pid_max=1048575\" | sudo tee -a /etc/sysctl.conf",              # configure pid_max for cisco 8000e containers
       "sudo sysctl -p",
     ]

--- a/cloudbuild/internal.pkr.hcl
+++ b/cloudbuild/internal.pkr.hcl
@@ -73,7 +73,7 @@ build {
       "sudo usermod -aG docker $USER",
       "sudo docker version",
       "sudo apt-get install openvswitch-switch-dpdk -y",   # install openvswitch for cisco containers
-      "echo \"fs.inotify.max_user_instances=64000\" | sudo tee -a /etc/sysctl.conf", # configure inotify for cisco xrd containers
+      "echo \"fs.inotify.max_user_instances=128000\" | sudo tee -a /etc/sysctl.conf", # configure inotify for cisco xrd containers
       "echo \"kernel.pid_max=1048575\" | sudo tee -a /etc/sysctl.conf",              # configure pid_max for cisco 8000e containers
       "sudo sysctl -p",
       "echo Pulling containers...",


### PR DESCRIPTION
```
ERROR - Not enough inotify instance resource available for new XRd instance.
Current settings are 64000 max_user_instances and 1004879 max_user_watches.
Each XRd instance is expected to need 4000 of each - please consider
setting the limits high (e.g. 64000, or higher).
```

For a 32 CPU topo, an upper limit of 32 XRDs could fit. 32*4000=128000