### PR TITLE
Disable nodeport auto allocation

### DIFF
--- a/topo/node/node.go
+++ b/topo/node/node.go
@@ -515,6 +515,12 @@ func (n *Impl) CreateService(ctx context.Context) error {
 				"app": n.Name(),
 			},
 			Type: "LoadBalancer",
+			// Do not allocate a NodePort for this LoadBalancer. MetalLB
+			// or the equivalent load balancer should handle exposing this service.
+			// Large topologies may try to allocate more NodePorts than are
+			// supported in default clusters.
+			// https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+			AllocateLoadBalancerNodePorts: pointer.Bool(false),
 		},
 	}
 	sS, err := n.KubeClient.CoreV1().Services(n.Namespace).Create(ctx, s, metav1.CreateOptions{})

--- a/topo/node/node_test.go
+++ b/topo/node/node_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 )
 
 func NewNR(impl *Impl) (Node, error) {
@@ -252,8 +253,9 @@ func TestService(t *testing.T) {
 					TargetPort: intstr.FromInt(22),
 					NodePort:   0,
 				}},
-				Selector: map[string]string{"app": "dev1"},
-				Type:     "LoadBalancer",
+				Selector:                      map[string]string{"app": "dev1"},
+				Type:                          "LoadBalancer",
+				AllocateLoadBalancerNodePorts: pointer.Bool(false),
 			},
 		}},
 	}, {
@@ -297,8 +299,9 @@ func TestService(t *testing.T) {
 					TargetPort: intstr.FromInt(9339),
 					NodePort:   0,
 				}},
-				Selector: map[string]string{"app": "dev2"},
-				Type:     "LoadBalancer",
+				Selector:                      map[string]string{"app": "dev2"},
+				Type:                          "LoadBalancer",
+				AllocateLoadBalancerNodePorts: pointer.Bool(false),
 			},
 		}},
 	}, {


### PR DESCRIPTION
Do not allocate a NodePort for this LoadBalancer. MetalLB or the equivalent load balancer should handle exposing this service. Large topologies may try to allocate more NodePorts than are supported in default clusters.

https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation

https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport (by default <3k services are allowed, with nodes having ~5 services this limits topo size)