### PR TITLE
Wait for manifest-issued deployments to complete before proceeding with Topology generation

### DIFF
--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -311,6 +311,7 @@ func TestKindSpec(t *testing.T) {
 			{Cmd: "docker", Args: []string{"tag", "docker", "local"}, OutOfOrder: true},
 			{Cmd: "docker", Args: []string{"pull", "gar"}, OutOfOrder: true},
 			{Cmd: "docker", Args: []string{"tag", "gar", "docker"}, OutOfOrder: true},
+			{Cmd: "kubectl", Args: []string{"rollout", "status", "deployment", "-w"}},
 		},
 	}, {
 		desc: "failed create cluster load containers additional manifests",


### PR DESCRIPTION
This is needed to ensure that any deployments that are started by the additional manifests (e.g., a mutating webhook) are completed before proceeding with later stages such as topology creation.

Not waiting for the deployment to finish before starting to create the topology results in potential race conditions in which a webhook isn't listening yet but is already requested to address admission requests, leading to "connection refused" error messages. 