### PR TITLE
docs - update kind version

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,12 +64,12 @@ sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 ## Install Kind
 
-> NOTE: This will install version `0.19.0` which was known to work with KNE at
+> NOTE: This will install version `0.24.0` which was known to work with KNE at
 > some point in time. You can instead install a newer version if you need new
 > features or are having problems.
 
 ```bash
-go install sigs.k8s.io/kind@v0.19.0
+go install sigs.k8s.io/kind@v0.24.0
 ```
 
 ## Clone openconfig/kne GitHub repo


### PR DESCRIPTION
The version requirement was bumped in 3315c2, resulting in the a build failure when following the documentation.

Current behaviour:
```
$ kne deploy deploy/kne/kind-bridge.yaml
I0105 09:09:28.147208   67772 deploy.go:195] Deploying cluster...
Error: failed to deploy cluster: failed to check for dependencies: kind version check failed: got 0.19.0, want 0.24.0. install with `go install sigs.k8s.io/kind@0.24.0`
```

New behaviour:
```
$ kne deploy deploy/kne/kind-bridge.yaml
I0105 09:13:48.483372   71859 deploy.go:195] Deploying cluster...
I0105 09:13:48.498972   71859 deploy.go:619] kind version valid: got 0.24.0 want 0.24.0
```