### PR TITLE
deploy - correct go install output

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -614,7 +614,7 @@ func (k *KindSpec) checkDependencies() error {
 			return fmt.Errorf("kind version check failed: %w", err)
 		}
 		if gotV.LT(wantV) {
-			return fmt.Errorf("kind version check failed: got %s, want %s. install with `go install sigs.k8s.io/kind@%s`", gotV, wantV, wantV)
+			return fmt.Errorf("kind version check failed: got %s, want %s. install with `go install sigs.k8s.io/kind@v%s`", gotV, wantV, wantV)
 		}
 		log.Infof("kind version valid: got %s want %s", gotV, wantV)
 	}


### PR DESCRIPTION
Upon an invalid `kind` version, the following message is displayed:
Error: failed to deploy cluster: failed to check for dependencies: kind version check failed: got 0.19.0, want 0.24.0. install with `go install sigs.k8s.io/kind@0.24.0`

Executing the instruction fails, due to an in-valid version tag: `go: sigs.k8s.io/kind@0.24.0: sigs.k8s.io/kind@0.24.0: invalid version: unknown revision 0.24.0`

The `v` is being stripped off by `parseVersion` as changed in 1d152a.

Since `parseVersion` explicitly requires a `v` prefix, it should be safe to just add this back in the human output.