### PR TITLE
meshnet - update node selector

### DIFF
--- a/manifests/meshnet/grpc/manifest.yaml
+++ b/manifests/meshnet/grpc/manifest.yaml
@@ -316,7 +316,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       serviceAccountName: meshnet
       terminationGracePeriodSeconds: 30
       tolerations:

--- a/manifests/meshnet/vxlan/manifest.yaml
+++ b/manifests/meshnet/vxlan/manifest.yaml
@@ -316,7 +316,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       serviceAccountName: meshnet
       terminationGracePeriodSeconds: 30
       tolerations:


### PR DESCRIPTION
The current manifest results in a warning:
```
W0105 09:36:05.398257   83130 run.go:29] (kubectl): Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use "kubernetes.io/arch" instead
```

Originally (9c3f3a) the `kubernetes.io/arch` label was used, until it was swapped to `beta.kubernetes.io/arch` in 36b380.

The current documentation references `1.27.3`, with the latest release being `1.32.0`. The referenced version at the time of 36b380 was `1.24.1`.