### PR TITLE
Remove deprecated golangci config options

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -43,12 +43,6 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: true
-  govet:
-    # report about shadowed variables
-    check-shadowing: false
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   gocritic:
     disabled-checks:
       - singleCaseSwitch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # Kubernetes Network Emulation
 
 [![Actions Status](https://github.com/openconfig/kne/workflows/Go/badge.svg)](https://github.com/openconfig/kne/actions)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # Kubernetes Network Emulation
 
 [![Actions Status](https://github.com/openconfig/kne/workflows/Go/badge.svg)](https://github.com/openconfig/kne/actions)


### PR DESCRIPTION
The "check-shadowing" knob is now just called "shadow" and disabled by default, and "maligned" is deprecated ([ref](https://github.com/golangci/golangci-lint/blob/master/CHANGELOG.md))