### PR TITLE
Update the KNE setup doc

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,8 +1,8 @@
 # Setup KNE
 
 This is part of the How-To guide collection. This guide covers KNE first time
-setup on a Linux machine. Specifically the `Ubuntu Focal 20.04 (LTS)` base
-image. Modifications may need to be made to the commands listed below in order
+setup on a Linux machine. The guide has been verified on a Linux host with Debian 6.10.11-1rodete2. 
+Modifications may need to be made to the commands listed below in order
 to work with your Linux distribution.
 
 The following dependencies and required to use KNE:
@@ -16,30 +16,23 @@ The following dependencies and required to use KNE:
 ## Install Golang
 
 1. If golang is already installed then check the version using `go version`. If
-   `1.21` or newer then golang installation is complete.
-
-1. Install the new version:
+   `1.23` or newer then golang installation is complete. Otherwise please follow the [instructions] (https://go.dev/doc/install) 
+   to install golang.
+   Please export GOPATH and add the export commands to ~/.bashrc or similar.
 
    ```bash
-   curl -O https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz
-   sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.21.3.linux-amd64.tar.gz
-   rm go1.21.3.linux-amd64.tar.gz
-   export PATH=$PATH:/usr/local/go/bin
    export PATH=$PATH:$(go env GOPATH)/bin
    ```
 
-   Consider adding the `export` commands to `~/.bashrc` or similar.
 
 ## Install Docker
 
-> NOTE: This will install version `20.10.16` which was known to work with KNE at
+> NOTE: This will install version `20.10.21` which was known to work with KNE at
 > some point in time. You can instead install a newer version if you need new
 > features or are having problems.
 
 1. Follow the installation
-   [instructions](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
-   using version string `5:20.10.16~3-0~ubuntu-focal` or the equivalent
-   `20.10.16` version for the corresponding OS.
+   [instructions](https://docs.docker.com/engine/install/debian)
 
 2. Follow the [post-installation
    steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
@@ -53,23 +46,25 @@ The following dependencies and required to use KNE:
 
 ## Install kubectl
 
-> NOTE: This will install version `1.27.3` which was known to work with KNE at
+> NOTE: This will install version `1.32.3` which was known to work with KNE at
 > some point in time. You can instead install a newer version if you need new
 > features or are having problems.
+1. Follow the installation:
+   [instructions](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
 
 ```bash
-curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 ```
 
 ## Install Kind
 
-> NOTE: This will install version `0.24.0` which was known to work with KNE at
+> NOTE: This will install version `0.27.0` which was known to work with KNE at
 > some point in time. You can instead install a newer version if you need new
 > features or are having problems.
 
 ```bash
-go install sigs.k8s.io/kind@v0.24.0
+go install sigs.k8s.io/kind@v0.27.0
 ```
 
 ## Clone openconfig/kne GitHub repo
@@ -83,6 +78,7 @@ git clone https://github.com/openconfig/kne.git
 Install the `kne` binary:
 
 ```bash
+cd kne
 make install
 ```
 


### PR DESCRIPTION
Update the KNE setup instructions to use newer version of go, docker, kubectl and kind. 
The steps have been verified on a newly created VM host.