### PR TITLE
kmendelev: Switch Cisco 8000e authentication from Type 7 to Type 10

### DIFF
--- a/examples/cisco/8000e/r1.config
+++ b/examples/cisco/8000e/r1.config
@@ -1,10 +1,9 @@
-!! IOS XR Configuration 7.4.1
-!! Last configuration change at Wed Aug 18 19:55:09 2021 by cisco
+!! IOS XR Configuration 
 !
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret 10 $6$nd8Pp1emKxgJDp1.$PeQSLpqjl3esYN6QmpmWPFuS.34wiD7Fb7cxVvx8sQXpvvPwhXVUx5pFm4vRxxrV.qK7uhFKCzdhyDDgXXirE.
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255

--- a/examples/cisco/8000e/r2.config
+++ b/examples/cisco/8000e/r2.config
@@ -1,10 +1,9 @@
-!! IOS XR Configuration 7.4.1
-!! Last configuration change at Wed Aug 18 19:55:09 2021 by cisco
+!! IOS XR Configuration
 !
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret 10 $6$nd8Pp1emKxgJDp1.$PeQSLpqjl3esYN6QmpmWPFuS.34wiD7Fb7cxVvx8sQXpvvPwhXVUx5pFm4vRxxrV.qK7uhFKCzdhyDDgXXirE.
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255


### PR DESCRIPTION
Per Cisco: type 7 passwords are deprecated in newer releases. Here's  some details.

https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/25xx/configuration/guide/b-system-security-cg-cisco8000-25xx/configuring-aaa-services.html#concept_lbt_ywl_g2c

The change validated via smoke test (Google environment).