### PR TITLE
Relax validation for inclusterproxy node interface check

### DIFF
--- a/topo/node/inclusterproxy/inclusterproxy.go
+++ b/topo/node/inclusterproxy/inclusterproxy.go
@@ -124,11 +124,6 @@ func (n *Node) validate() error {
 		return fmt.Errorf("node %s: interface must be 'eth1'", n.Name())
 	}
 
-	// Enforce link to target node
-	peerNodeName := pb.Labels["proxy-pool-for"]
-	if eth1.PeerName != peerNodeName {
-		return fmt.Errorf("node %s: eth1 must be connected to %s, found %s", n.Name(), peerNodeName, eth1.PeerName)
-	}
 
 	// Ensure exactly 1 service
 	if len(pb.Services) != 1 {

--- a/topo/node/inclusterproxy/inclusterproxy.go
+++ b/topo/node/inclusterproxy/inclusterproxy.go
@@ -119,11 +119,10 @@ func (n *Node) validate() error {
 	if len(pb.Interfaces) != 1 {
 		return fmt.Errorf("node %s: exactly one interface is required, found %d", n.Name(), len(pb.Interfaces))
 	}
-	eth1, ok := pb.Interfaces["eth1"]
+	_, ok := pb.Interfaces["eth1"]
 	if !ok {
 		return fmt.Errorf("node %s: interface must be 'eth1'", n.Name())
 	}
-
 
 	// Ensure exactly 1 service
 	if len(pb.Services) != 1 {

--- a/topo/node/inclusterproxy/inclusterproxy_test.go
+++ b/topo/node/inclusterproxy/inclusterproxy_test.go
@@ -74,21 +74,6 @@ func TestNew(t *testing.T) {
 		},
 		wantErr: "interface must be 'eth1'",
 	}, {
-		desc: "mismatched peer name",
-		ni: &node.Impl{
-			Proto: &topopb.Node{
-				Name: "test_node",
-				Labels: map[string]string{
-					"proxy-pool-for": "dut1",
-				},
-				Interfaces: map[string]*topopb.Interface{
-					"eth1": {PeerName: "wrong_dut"},
-				},
-				Services: map[uint32]*topopb.Service{1: {Inside: 1}},
-			},
-		},
-		wantErr: "eth1 must be connected to dut1, found wrong_dut",
-	}, {
 		desc: "multiple services not allowed",
 		ni: &node.Impl{
 			Proto: &topopb.Node{


### PR DESCRIPTION
Previously, validation strictly failed if `eth1.PeerName` did not match the `proxy-pool-for` label at node instantiation time. This change makes connectivity validation conditional on `PeerName` being non-empty so that the pre-load step succeeds.