### PR TITLE
Fix broken example topologies

### DIFF
--- a/examples/arista/ceos-ipv6/ceos-ipv6.pb.txt
+++ b/examples/arista/ceos-ipv6/ceos-ipv6.pb.txt
@@ -122,5 +122,5 @@ links: {
     a_node: "r3"
     a_int: "eth9"
     z_node: "otg"
-    z_int: "eth1"
+    z_int: "eth2"
 }

--- a/examples/cisco/xrd-traffic/xrd-traffic.pb.txt
+++ b/examples/cisco/xrd-traffic/xrd-traffic.pb.txt
@@ -68,11 +68,5 @@ links: {
     a_node: "r2"
     a_int: "eth2"
     z_node: "otg"
-    z_int: "eth1"
-}
-links: {
-    a_node: "r3"
-    a_int: "eth3"
-    z_node: "otg"
-    z_int: "eth1"
+    z_int: "eth2"
 }


### PR DESCRIPTION
* ceos-ipv6: fix duplicated reference to otg:eth1
* xrd-traffic: fix duplicated reference to otg:eth1, remove link from nonexistent r3