### PR TITLE
fix(node): sanitize special characters and escape sequences in config

### DIFF
--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -53,6 +53,8 @@ const (
 )
 
 var (
+	validPathRegexp = regexp.MustCompile(`^[A-Za-z0-9._/:-]+$`)
+
 	defaultXRDConstraints = node.Constraints{
 		CPU:    "1000m", // 1000 milliCPUs
 		Memory: "2Gi",   // 2 GB RAM
@@ -663,6 +665,17 @@ func endTelnet(d *scraplinetwork.Driver) error {
 
 func (n *Node) ResetCfg(ctx context.Context) error {
 	log.Infof("%s resetting config", n.Name())
+	var startupConfig string
+	if n.Proto.Model == ModelXRD {
+		startupConfig = n.Proto.Config.Env["XR_EVERY_BOOT_CONFIG"]
+		if startupConfig == "" {
+			return status.Errorf(codes.InvalidArgument, "XR_EVERY_BOOT_CONFIG is not set")
+		}
+		if !validPathRegexp.MatchString(startupConfig) {
+			return status.Errorf(codes.InvalidArgument, "invalid XR_EVERY_BOOT_CONFIG %q: must match %s", startupConfig, validPathRegexp.String())
+		}
+	}
+
 	err := n.SpawnCLIConn()
 	if err != nil {
 		return err
@@ -674,12 +687,8 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 		// Copy the snooped management interface config from a know location and the startup config from
 		// the mounted location so it can be applied. This is required to preserve the snooped management
 		// IP addres and since the "copy" xr_cli command can only access files on disk 0/1.
-		startup_config := n.Proto.Config.Env["XR_EVERY_BOOT_CONFIG"]
-		if startup_config == "" {
-			return status.Errorf(codes.InvalidArgument, "XR_EVERY_BOOT_CONFIG is not set")
-		}
 		// Send an additional return command to make sure any error messages are read.
-		copyCfgCmd := "cat " + xrdInterfaceConfig + " " + startup_config + " > /disk0:/startup-config"
+		copyCfgCmd := "cat " + xrdInterfaceConfig + " " + startupConfig + " > /disk0:/startup-config"
 		resp, err := n.cliConn.SendCommands([]string{copyCfgCmd, ""})
 		if err != nil {
 			return err

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -279,7 +279,7 @@ func (n *Node) Create(ctx context.Context) error {
 }
 
 // DefaultNodeConstraints returns default node constraints for CISCO.
-// If the model for 8000e is specificied correctly it returns defaults for 8000e.
+// If the model for 8000e is specified correctly it returns defaults for 8000e.
 // Otherwise, it returns defaults for XRD by default.
 func (n *Node) DefaultNodeConstraints() node.Constraints {
 	if n.Impl == nil || n.Impl.Proto == nil {
@@ -294,7 +294,7 @@ func (n *Node) DefaultNodeConstraints() node.Constraints {
 	return defaultXRDConstraints
 }
 
-// validateHostConstraints - Validates host contraints through the default node's implementation. It skips the validation optionally
+// validateHostConstraints - Validates host constraints through the default node's implementation. It skips the validation optionally
 // based on skipValidation flag which is useful for unit tests
 func validateHostConstraints(n *Node, skipValidation bool) error {
 	if skipValidation {
@@ -686,7 +686,7 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 	if n.Proto.Model == ModelXRD {
 		// Copy the snooped management interface config from a know location and the startup config from
 		// the mounted location so it can be applied. This is required to preserve the snooped management
-		// IP addres and since the "copy" xr_cli command can only access files on disk 0/1.
+		// IP address and since the "copy" xr_cli command can only access files on disk 0/1.
 		// Send an additional return command to make sure any error messages are read.
 		copyCfgCmd := "cat " + xrdInterfaceConfig + " " + startupConfig + " > /disk0:/startup-config"
 		resp, err := n.cliConn.SendCommands([]string{copyCfgCmd, ""})
@@ -766,7 +766,7 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 func (n *Node) GenerateSelfSigned(context.Context) error {
 	// IOS XR automatically generates a self-signed certificate when gRPC is first enabled.
 	// If the startup configuration contains a gRPC configuration, or if the user configures
-	// gRPC after bootup, the self-signed cert will automatically be created and used.
+	// gRPC after boot-up, the self-signed cert will automatically be created and used.
 	return status.Errorf(codes.Unimplemented, "certificate generation is not supported")
 }
 

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -902,6 +902,21 @@ var (
 			Model:  ModelXRD,
 		},
 	}
+
+	nodeXRDInvalidPath = &node.Impl{
+		KubeClient: ki,
+		Namespace:  "test",
+		Proto: &tpb.Node{
+			Name:   "xrd",
+			Vendor: tpb.Vendor_CISCO,
+			Config: &tpb.Config{
+				Env: map[string]string{
+					"XR_EVERY_BOOT_CONFIG": "/etc/config/test;invalid",
+				},
+			},
+			Model: ModelXRD,
+		},
+	}
 )
 
 func TestNodeStatus(t *testing.T) {
@@ -978,6 +993,12 @@ func TestResetCfg(t *testing.T) {
 			wantErr:  true,
 			ni:       nodeXRD,
 			testFile: "testdata/xrd_reset_config_failure_invalid",
+		},
+		{
+			// device returns error when startup_config path contains invalid characters
+			desc:    "failed reset for XRd (invalid path characters)",
+			wantErr: true,
+			ni:      nodeXRDInvalidPath,
 		},
 		{
 			// device returns success after applying the startup config
@@ -1166,6 +1187,29 @@ func TestDefaultNodeConstraints(t *testing.T) {
 
 			if constraints.Memory != tt.wantMemory {
 				t.Errorf("DefaultNodeConstraints() returned unexpected Memory: got %s, want %s", constraints.Memory, tt.wantMemory)
+			}
+		})
+	}
+}
+
+func TestValidPathRegexp(t *testing.T) {
+	tests := []struct {
+		path      string
+		wantValid bool
+	}{
+		{"/disk0:/startup-config", true},
+		{"/etc/config/xr.cfg", true},
+		{"/etc/config/test;path", false},
+		{"/path/with spaces", false},
+		{"/path/test$cfg", false},
+		{"/path/test`cfg`", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := validPathRegexp.MatchString(tt.path)
+			if got != tt.wantValid {
+				t.Errorf("validPathRegexp.MatchString(%q) = %v, want %v", tt.path, got, tt.wantValid)
 			}
 		})
 	}

--- a/topo/node/juniper/juniper.go
+++ b/topo/node/juniper/juniper.go
@@ -172,7 +172,7 @@ func (n *Node) SpawnCLIConn() error {
 }
 
 // DefaultNodeConstraints returns default node constraints for Juniper.
-// If the model for cptx is specificied correctly it returns defaults for cptx.
+// If the model for cptx is specified correctly it returns defaults for cptx.
 // Otherwise, it returns defaults for ncptx by default.
 func (n *Node) DefaultNodeConstraints() node.Constraints {
 	if n.Impl == nil || n.Impl.Proto == nil {

--- a/topo/node/juniper/juniper.go
+++ b/topo/node/juniper/juniper.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -252,14 +253,21 @@ func (n *Node) waitConfigInfraReadyAndPushConfigs(configs []string) error {
 	return fmt.Errorf("failed sending configs")
 }
 
+// validCertNameRegexp defines the allowed characters in a certificate name.
+var validCertNameRegexp = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
 // Waits and retries until Cert infra is up and certs are applied
 func (n *Node) waitCertInfraReadyAndPushCert() error {
 	selfSigned := n.Proto.GetConfig().GetCert().GetSelfSigned()
+	certName := selfSigned.GetCertName()
+	if !validCertNameRegexp.MatchString(certName) {
+		return fmt.Errorf("invalid cert name %q: must match %s", certName, validCertNameRegexp.String())
+	}
 	commands := []string{
-		fmt.Sprintf("request security pki generate-key-pair certificate-id %s", selfSigned.GetCertName()),
+		fmt.Sprintf("request security pki generate-key-pair certificate-id %s", certName),
 		fmt.Sprintf("request security pki local-certificate generate-self-signed certificate-id %s "+
 			"subject CN=abc domain-name google.com ip-address 1.2.3.4 email example@google.com",
-			selfSigned.GetCertName()),
+			certName),
 	}
 
 	log.Infof("Waiting for certificates to be pushed (timeout: %v) node %s", certGenTimeout, n.Name())
@@ -293,6 +301,10 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 	if selfSigned == nil {
 		log.Infof("%s - no cert config", n.Name())
 		return nil
+	}
+	certName := selfSigned.GetCertName()
+	if !validCertNameRegexp.MatchString(certName) {
+		return fmt.Errorf("invalid cert name %q: must match %s", certName, validCertNameRegexp.String())
 	}
 	log.Infof("%s - generating self signed certs", n.Name())
 	log.Infof("%s - waiting for pod to be running", n.Name())

--- a/topo/node/juniper/juniper_test.go
+++ b/topo/node/juniper/juniper_test.go
@@ -188,6 +188,29 @@ func TestGenerateSelfSigned(t *testing.T) {
 			ni:       ni,
 			testFile: "testdata/generate_certificate_config_mode_failure",
 		},
+		{
+			// invalid cert name contains invalid characters
+			desc:     "invalid cert name characters",
+			wantErr:  true,
+			testFile: "testdata/generate_certificate_failure",
+			ni: &node.Impl{
+				KubeClient: ki,
+				Namespace:  "test",
+				Proto: &tpb.Node{
+					Name:   "pod1",
+					Vendor: tpb.Vendor_JUNIPER,
+					Config: &tpb.Config{
+						Cert: &tpb.CertificateCfg{
+							Config: &tpb.CertificateCfg_SelfSigned{
+								SelfSigned: &tpb.SelfSignedCertCfg{
+									CertName: "grpc-cert;invalid",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -865,6 +888,29 @@ func TestDefaultNodeConstraints(t *testing.T) {
 
 			if constraints.Memory != tt.wantMemory {
 				t.Errorf("DefaultNodeConstraints() returned unexpected Memory: got %s, want %s", constraints.Memory, tt.wantMemory)
+			}
+		})
+	}
+}
+
+func TestValidCertNameRegexp(t *testing.T) {
+	tests := []struct {
+		certName  string
+		wantValid bool
+	}{
+		{"grpc-server-cert", true},
+		{"my_cert.v1-2", true},
+		{"cert;invalid", false},
+		{"cert$invalid", false},
+		{"cert/invalid", false},
+		{"cert name spaces", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.certName, func(t *testing.T) {
+			got := validCertNameRegexp.MatchString(tt.certName)
+			if got != tt.wantValid {
+				t.Errorf("validCertNameRegexp.MatchString(%q) = %v, want %v", tt.certName, got, tt.wantValid)
 			}
 		})
 	}

--- a/topo/node/nokia/nokia.go
+++ b/topo/node/nokia/nokia.go
@@ -47,6 +47,13 @@ var (
 		CPU:    "2000m", // 2000 milliCPUs
 		Memory: "4Gi",   // 4 GB RAM
 	}
+
+	configEscaper = strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"`", "\\`",
+		"$", `\$`,
+	)
 )
 
 var (
@@ -187,9 +194,9 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 		return err
 	}
 
-	// replace quotes in the config with escaped quotes, so that we can echo this config
+	// replace quotes and special characters in the config with escaped characters, so that we can echo this config
 	// via `echo` CLI commands.
-	cfg := strings.ReplaceAll(string(cfgBytes), `"`, `\"`)
+	cfg := escapeConfig(cfgBytes)
 
 	log.V(1).Infof("config to push:\n%s", cfg)
 
@@ -236,6 +243,11 @@ func (n *Node) ConfigPush(ctx context.Context, r io.Reader) error {
 	log.Infof("%s - finished pushing config", n.Name())
 
 	return nil
+}
+
+// escapeConfig escapes special characters in cfgBytes.
+func escapeConfig(cfgBytes []byte) string {
+	return configEscaper.Replace(string(cfgBytes))
 }
 
 // Create creates a Nokia SR Linux node by interfacing with srl-labs/srl-controller

--- a/topo/node/nokia/nokia_test.go
+++ b/topo/node/nokia/nokia_test.go
@@ -477,3 +477,46 @@ func TestDefaultNodeConstraints(t *testing.T) {
 		t.Errorf("DefaultNodeConstraints() returned unexpected Memory: got %s, want %s", constraints.Memory, defaultConstraints.Memory)
 	}
 }
+
+func TestEscapeConfig(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+		want  string
+	}{
+		{
+			desc:  "plain text",
+			input: "set system location foo",
+			want:  "set system location foo",
+		},
+		{
+			desc:  "double quotes",
+			input: "set / system location \"set with config push\"",
+			want:  `set / system location \"set with config push\"`,
+		},
+		{
+			desc:  "dollar signs",
+			input: "set / system location $(value)",
+			want:  `set / system location \$(value)`,
+		},
+		{
+			desc:  "backticks",
+			input: "set / system location `value`",
+			want:  "set / system location \\`value\\`",
+		},
+		{
+			desc:  "backslashes and dollar signs",
+			input: `set / system location \path\$ENV`,
+			want:  `set / system location \\path\\\$ENV`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := escapeConfig([]byte(tt.input))
+			if got != tt.want {
+				t.Errorf("escapeConfig(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add character allowlist validation for Juniper certificate names in waitCertInfraReadyAndPushCert and GenerateSelfSigned.
- Add character allowlist validation for Cisco XRd startup configuration paths in ResetCfg.
- Improve escaping of special characters (\, ", `, and $) in Nokia SR Linux configuration strings before sending via CLI.