### PR TITLE
build(cloudbuild): pin kubectl version to 578

### DIFF
--- a/cloudbuild/external.pkr.hcl
+++ b/cloudbuild/external.pkr.hcl
@@ -99,7 +99,8 @@ build {
       "sudo apt-get update",
       // kube-proxy requires conntrack to route traffic, and kubeadm v1.31+ enforces it in preflight checks
       "sudo apt-get install conntrack -y",
-      "sudo apt-get install kubelet kubeadm kubectl -y",
+      // TODO: Remove pin when kubectl reports a version number other than `v0.0.0-master+$Format:%H$`.
+      "sudo apt-get install kubelet kubeadm kubectl=1:578.0.0-0 -y",
       "kubectl version --client",
       "echo 'source <(kubectl completion bash)' >> ~/.bashrc",
       "echo 'alias k=kubectl' >> ~/.bashrc",

--- a/cloudbuild/internal.pkr.hcl
+++ b/cloudbuild/internal.pkr.hcl
@@ -111,7 +111,8 @@ build {
       "sudo apt-get update",
       // kube-proxy requires conntrack to route traffic, and kubeadm v1.31+ enforces it in preflight checks
       "sudo apt-get install conntrack -y",
-      "sudo apt-get install kubelet kubeadm kubectl -y",
+      // TODO: Remove pin when kubectl reports a version number other than `v0.0.0-master+$Format:%H$`.
+      "sudo apt-get install kubelet kubeadm kubectl=1:578.0.0-0 -y",
       "kubectl version --client",
       "echo 'source <(kubectl completion bash)' >> ~/.bashrc",
       "echo 'alias k=kubectl' >> ~/.bashrc",


### PR DESCRIPTION
Pin kubectl package to 578. Version 579 seems to have an issue:

```
$ kubectl version --client
Client Version: v0.0.0-master+$Format:%H$
Kustomize Version: v5.7.1
```

The previous version returns a string:
```
$ kubectl version --client
Client Version: v1.35.6-dispatcher
Kustomize Version: v5.7.1
```

kne tries to validate the cluster version using kubectl and this fails because kubectl is reporting the default version as if it was compiled without a version populated.  kne deploy will give an error along the lines of: `failed to deploy cluster: kubectl version outside of supported range: failed get kubectl version: "/usr/bin/kubectl version --output=yaml" failed: exit status 1`. 

Example of the problem (older k8s and `/usr/lib/google-cloud-sdk/bin/kubectl.1.26.0` does not exist):
```
$ kubectl version
Client Version: v0.0.0-master+$Format:%H$
Kustomize Version: v5.7.1
Server Version: v1.26.0
error: client version error: could not parse pre-release/metadata (-master+$Format:%H$) in version "v0.0.0-master+$Format:%H$"
$ echo $?
1
```

This should be reverted when a newer version of kubectl reports a valid version number.