### PR TITLE
Improve KNE startup performance

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -207,6 +207,12 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) (rerr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create k8s config: %w", err)
 	}
+	if rCfg.QPS == 0 {
+		rCfg.QPS = 100
+	}
+	if rCfg.Burst == 0 {
+		rCfg.Burst = 200
+	}
 	kClient, err := kubernetes.NewForConfig(rCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %w", err)

--- a/third_party/meshnet/daemon/meshnet/meshnet.go
+++ b/third_party/meshnet/daemon/meshnet/meshnet.go
@@ -74,6 +74,12 @@ func restConfig() (*rest.Config, error) {
 			return nil, err
 		}
 	}
+	if rCfg.QPS == 0 {
+		rCfg.QPS = 100
+	}
+	if rCfg.Burst == 0 {
+		rCfg.Burst = 200
+	}
 	return rCfg, nil
 }
 

--- a/topo/node/cisco/cisco_test.go
+++ b/topo/node/cisco/cisco_test.go
@@ -1040,7 +1040,7 @@ func TestResetCfg(t *testing.T) {
 			n.testOpts = []scrapliutil.Option{
 				scrapliopts.WithTransportType(scraplitransport.FileTransport),
 				scrapliopts.WithFileTransportFile(tt.testFile),
-				scrapliopts.WithTimeoutOps(10 * time.Second),
+				scrapliopts.WithTimeoutOps(2 * time.Second),
 				scrapliopts.WithTransportReadSize(1),
 				scrapliopts.WithReadDelay(0),
 				scrapliopts.WithDefaultLogger(),
@@ -1106,7 +1106,7 @@ func TestPushCfg(t *testing.T) {
 			n.testOpts = []scrapliutil.Option{
 				scrapliopts.WithTransportType(scraplitransport.FileTransport),
 				scrapliopts.WithFileTransportFile(tt.testFile),
-				scrapliopts.WithTimeoutOps(10 * time.Second),
+				scrapliopts.WithTimeoutOps(2 * time.Second),
 				scrapliopts.WithTransportReadSize(1),
 				scrapliopts.WithReadDelay(0),
 				scrapliopts.WithDefaultLogger(),

--- a/topo/node/juniper/juniper_test.go
+++ b/topo/node/juniper/juniper_test.go
@@ -146,13 +146,13 @@ func TestGenerateSelfSigned(t *testing.T) {
 	defer func() {
 		certGenTimeout = origCertGenTimeout
 	}()
-	certGenTimeout = time.Second * 10
+	certGenTimeout = time.Second * 2
 
 	origConfigModeTimeout := configModeTimeout
 	defer func() {
 		configModeTimeout = origConfigModeTimeout
 	}()
-	configModeTimeout = time.Second * 10
+	configModeTimeout = time.Second * 2
 
 	tests := []struct {
 		desc     string
@@ -226,7 +226,7 @@ func TestGenerateSelfSigned(t *testing.T) {
 			n.testOpts = []scrapliutil.Option{
 				scrapliopts.WithTransportType(scraplitransport.FileTransport),
 				scrapliopts.WithFileTransportFile(tt.testFile),
-				scrapliopts.WithTimeoutOps(10 * time.Second),
+				scrapliopts.WithTimeoutOps(2 * time.Second),
 				scrapliopts.WithTransportReadSize(1),
 				scrapliopts.WithReadDelay(0),
 				scrapliopts.WithDefaultLogger(),
@@ -390,7 +390,7 @@ func TestConfigPush(t *testing.T) {
 			n.testOpts = []scrapliutil.Option{
 				scrapliopts.WithTransportType(scraplitransport.FileTransport),
 				scrapliopts.WithFileTransportFile(tt.testFile),
-				scrapliopts.WithTimeoutOps(10 * time.Second),
+				scrapliopts.WithTimeoutOps(2 * time.Second),
 				scrapliopts.WithTransportReadSize(1),
 				scrapliopts.WithReadDelay(0),
 				scrapliopts.WithDefaultLogger(),
@@ -489,7 +489,7 @@ func TestResetCfg(t *testing.T) {
 			n.testOpts = []scrapliutil.Option{
 				scrapliopts.WithTransportType(scraplitransport.FileTransport),
 				scrapliopts.WithFileTransportFile(tt.testFile),
-				scrapliopts.WithTimeoutOps(10 * time.Second),
+				scrapliopts.WithTimeoutOps(2 * time.Second),
 				scrapliopts.WithTransportReadSize(1),
 				scrapliopts.WithReadDelay(0),
 				scrapliopts.WithDefaultLogger(),

--- a/topo/node/juniper/testdata/config_push_failure
+++ b/topo/node/juniper/testdata/config_push_failure
@@ -57,7 +57,9 @@ root@cptx2> start shell user root
 [vrf:none] root@cptx2:~#
 [vrf:none] root@cptx2:~# echo >> /config/scrapli_cfg_testing '    }'
 [vrf:none] root@cptx2:~#
-[vrf:none] root@cptx2:~# echo >> /config/scrapli_cfg_testing 'abcd'
+[vrf:none] root@cptx2:~# echo >> /config/scrapli_cfg_testing '}'
+[vrf:none] root@cptx2:~#
+[vrf:none] root@cptx2:~# echo >> /config/scrapli_cfg_testing ''
 [vrf:none] root@cptx2:~#
 [vrf:none] root@cptx2:~# exit
 logout

--- a/topo/node/juniper/testdata/config_reset_success
+++ b/topo/node/juniper/testdata/config_reset_success
@@ -26,8 +26,6 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
-
 root@cptx2> configure
 Entering configuration mode
 
@@ -121,4 +119,5 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
+root@cptx2>
+root@cptx2>

--- a/topo/node/juniper/testdata/generate_certificate_config_mode_failure
+++ b/topo/node/juniper/testdata/generate_certificate_config_mode_failure
@@ -16,10 +16,6 @@ root@cptx2> request security pki local-certificate generate-self-signed certific
 Self-signed certificate generated and loaded successfully
 
 root@cptx2>
-root@cptx2>exit
-
-root@cptx2>
-
 root@cptx2> configure
 error: unknown command: configure
 Configuration is allowed only from the Routing Engine with GlobalIPOwner attribute assigned. Please check "show system nodes" command output.
@@ -120,4 +116,5 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
+root@cptx2>
+root@cptx2>

--- a/topo/node/juniper/testdata/generate_certificate_config_mode_success
+++ b/topo/node/juniper/testdata/generate_certificate_config_mode_success
@@ -16,10 +16,6 @@ root@cptx2> request security pki local-certificate generate-self-signed certific
 Self-signed certificate generated and loaded successfully
 
 root@cptx2>
-root@cptx2>exit
-
-root@cptx2>
-
 root@cptx2> configure
 error: unknown command: configure
 Configuration is allowed only from the Routing Engine with GlobalIPOwner attribute assigned. Please check "show system nodes" command output.
@@ -120,4 +116,5 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
+root@cptx2>
+root@cptx2>

--- a/topo/node/juniper/testdata/generate_certificate_failure
+++ b/topo/node/juniper/testdata/generate_certificate_failure
@@ -16,10 +16,6 @@ root@cptx2> request security pki local-certificate generate-self-signed certific
 error: Command aborted as certificate already exists. Retry after clearing the existing certificate.
 
 root@cptx2>
-root@cptx2>exit
-
-root@cptx2>
-
 root@cptx2> configure
 Entering configuration mode
 
@@ -113,4 +109,5 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
+root@cptx2>
+root@cptx2>

--- a/topo/node/juniper/testdata/generate_certificate_success
+++ b/topo/node/juniper/testdata/generate_certificate_success
@@ -16,9 +16,6 @@ root@cptx2> request security pki local-certificate generate-self-signed certific
 Self-signed certificate generated and loaded successfully
 
 root@cptx2>
-root@cptx2>exit
-
-root@cptx2>
 root@cptx2> configure
 Entering configuration mode
 
@@ -112,4 +109,5 @@ root@cptx2#
 root@cptx2# exit configuration-mode
 Exiting configuration mode
 
-root@cptx2> exit
+root@cptx2>
+root@cptx2>

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -699,12 +699,12 @@ func (m *Manager) createMeshnetTopologies(ctx context.Context) error {
 		wg.Add(1)
 		go func(topo *topologyv1.Topology) {
 			defer wg.Done()
-			log.Infof("Creating topology for meshnet node %s", topo.ObjectMeta.Name)
+			log.Infof("Creating topology for meshnet node %s", topo.Name)
 			sT, err := m.tClient.Topology(m.topo.Name).Create(ctx, topo, metav1.CreateOptions{})
 			if err != nil {
 				mu.Lock()
 				if firstErr == nil {
-					firstErr = fmt.Errorf("could not create topology for meshnet node %s: %v", topo.ObjectMeta.Name, err)
+					firstErr = fmt.Errorf("could not create topology for meshnet node %s: %v", topo.Name, err)
 				}
 				mu.Unlock()
 				return
@@ -756,7 +756,7 @@ func (m *Manager) checkNodeStatus(ctx context.Context, timeout time.Duration) er
 				defer mu.Unlock()
 				if err != nil || phase == node.StatusFailed {
 					if firstErr == nil {
-						firstErr = fmt.Errorf("Node %s: Status %s Reason %v", nod, phase, err)
+						firstErr = fmt.Errorf("node %s: status %s reason %v", nod, phase, err)
 					}
 					return
 				}

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -735,14 +735,20 @@ func (m *Manager) deleteMeshnetTopologies(ctx context.Context) error {
 func (m *Manager) checkNodeStatus(ctx context.Context, timeout time.Duration) error {
 	foundAll := false
 	processed := make(map[string]bool)
-	var mu sync.Mutex
+
+	type statusResult struct {
+		name  string
+		nod   node.Node
+		phase node.Status
+		err   error
+	}
 
 	// Check until end state or timeout sec expired
 	start := time.Now()
 	for (timeout == 0 || time.Since(start) < timeout) && !foundAll {
 		foundAll = true
 		var wg sync.WaitGroup
-		var firstErr error
+		resCh := make(chan statusResult, len(m.nodes))
 		for name, n := range m.nodes {
 			if processed[name] {
 				continue
@@ -752,25 +758,22 @@ func (m *Manager) checkNodeStatus(ctx context.Context, timeout time.Duration) er
 			go func(name string, nod node.Node) {
 				defer wg.Done()
 				phase, err := nod.Status(ctx)
-				mu.Lock()
-				defer mu.Unlock()
-				if err != nil || phase == node.StatusFailed {
-					if firstErr == nil {
-						firstErr = fmt.Errorf("node %s: status %s reason %v", nod, phase, err)
-					}
-					return
-				}
-				if phase == node.StatusRunning {
-					log.Infof("Node %s: Status %s", nod, phase)
-					processed[name] = true
-				} else {
-					foundAll = false
-				}
+				resCh <- statusResult{name: name, nod: nod, phase: phase, err: err}
 			}(name, n)
 		}
 		wg.Wait()
-		if firstErr != nil {
-			return firstErr
+		close(resCh)
+
+		for res := range resCh {
+			if res.err != nil || res.phase == node.StatusFailed {
+				return fmt.Errorf("node %s: status %s reason %v", res.nod, res.phase, res.err)
+			}
+			if res.phase == node.StatusRunning {
+				log.Infof("Node %s: Status %s", res.nod, res.phase)
+				processed[res.name] = true
+			} else {
+				foundAll = false
+			}
 		}
 		if !foundAll {
 			time.Sleep(500 * time.Millisecond)

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -186,6 +186,12 @@ func New(topo *tpb.Topology, opts ...Option) (*Manager, error) {
 		}
 		m.rCfg = rCfg
 	}
+	if m.rCfg.QPS == 0 {
+		m.rCfg.QPS = 100
+	}
+	if m.rCfg.Burst == 0 {
+		m.rCfg.Burst = 200
+	}
 	if m.kClient == nil {
 		kClient, err := kubernetes.NewForConfig(m.rCfg)
 		if err != nil {
@@ -409,10 +415,19 @@ func (m *Manager) Show(ctx context.Context) (*cpb.ShowTopologyResponse, error) {
 		}
 	}
 	stateMap := &stateMap{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 	for _, n := range m.nodes {
-		phase, _ := n.Status(ctx)
-		stateMap.setNodeState(n.Name(), phase)
+		wg.Add(1)
+		go func(nd node.Node) {
+			defer wg.Done()
+			phase, _ := nd.Status(ctx)
+			mu.Lock()
+			stateMap.setNodeState(nd.Name(), phase)
+			mu.Unlock()
+		}(n)
 	}
+	wg.Wait()
 	return &cpb.ShowTopologyResponse{
 		State:    stateMap.topologyState(),
 		Topology: m.topo,
@@ -677,15 +692,28 @@ func (m *Manager) createMeshnetTopologies(ctx context.Context) error {
 		return fmt.Errorf("could not get meshnet topologies: %v", err)
 	}
 	log.V(2).Infof("Got topology specs for namespace %s: %+v", m.topo.Name, topologies)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
 	for _, t := range topologies {
-		log.Infof("Creating topology for meshnet node %s", t.ObjectMeta.Name)
-		sT, err := m.tClient.Topology(m.topo.Name).Create(ctx, t, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("could not create topology for meshnet node %s: %v", t.ObjectMeta.Name, err)
-		}
-		log.V(1).Infof("Meshnet Node:\n%+v\n", sT)
+		wg.Add(1)
+		go func(topo *topologyv1.Topology) {
+			defer wg.Done()
+			log.Infof("Creating topology for meshnet node %s", topo.ObjectMeta.Name)
+			sT, err := m.tClient.Topology(m.topo.Name).Create(ctx, topo, metav1.CreateOptions{})
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("could not create topology for meshnet node %s: %v", topo.ObjectMeta.Name, err)
+				}
+				mu.Unlock()
+				return
+			}
+			log.V(1).Infof("Meshnet Node:\n%+v\n", sT)
+		}(t)
 	}
-	return nil
+	wg.Wait()
+	return firstErr
 }
 
 // deleteMeshnetTopologies deletes meshnet resources for all available nodes.
@@ -707,28 +735,46 @@ func (m *Manager) deleteMeshnetTopologies(ctx context.Context) error {
 func (m *Manager) checkNodeStatus(ctx context.Context, timeout time.Duration) error {
 	foundAll := false
 	processed := make(map[string]bool)
+	var mu sync.Mutex
 
 	// Check until end state or timeout sec expired
 	start := time.Now()
 	for (timeout == 0 || time.Since(start) < timeout) && !foundAll {
 		foundAll = true
+		var wg sync.WaitGroup
+		var firstErr error
 		for name, n := range m.nodes {
-			if _, ok := processed[name]; ok {
+			if processed[name] {
 				continue
 			}
 
-			phase, err := n.Status(ctx)
-			if err != nil || phase == node.StatusFailed {
-				return fmt.Errorf("Node %s: Status %s Reason %v", n, phase, err)
-			}
-			if phase == node.StatusRunning {
-				log.Infof("Node %s: Status %s", n, phase)
-				processed[name] = true
-			} else {
-				foundAll = false
-			}
+			wg.Add(1)
+			go func(name string, nd node.Node) {
+				defer wg.Done()
+				phase, err := nd.Status(ctx)
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil || phase == node.StatusFailed {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("Node %s: Status %s Reason %v", nd, phase, err)
+					}
+					return
+				}
+				if phase == node.StatusRunning {
+					log.Infof("Node %s: Status %s", nd, phase)
+					processed[name] = true
+				} else {
+					foundAll = false
+				}
+			}(name, n)
 		}
-		time.Sleep(100 * time.Millisecond)
+		wg.Wait()
+		if firstErr != nil {
+			return firstErr
+		}
+		if !foundAll {
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 	if !foundAll {
 		log.Warningf("Failed to determine status of some node resources in %d sec", timeout)
@@ -752,18 +798,41 @@ func (m *Manager) Resources(ctx context.Context) (*Resources, error) {
 		Topologies: map[string]*topologyv1.Topology{},
 	}
 
+	podList, err := m.kClient.CoreV1().Pods(m.topo.Name).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods for topology %s: %w", m.topo.Name, err)
+	}
+	podMap := map[string][]*corev1.Pod{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		podMap[pod.Name] = append(podMap[pod.Name], pod)
+	}
+
+	serviceList, err := m.kClient.CoreV1().Services(m.topo.Name).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services for topology %s: %w", m.topo.Name, err)
+	}
+	svcMap := map[string][]*corev1.Service{}
+	for i := range serviceList.Items {
+		svc := &serviceList.Items[i]
+		nodeName := strings.TrimPrefix(svc.Name, "service-")
+		svcMap[nodeName] = append(svcMap[nodeName], svc)
+	}
+
 	for nodeName, n := range m.nodes {
-		pods, err := n.Pods(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not get pods for node %s: %v", nodeName, err)
+		pods, ok := podMap[nodeName]
+		if !ok || len(pods) == 0 {
+			return nil, fmt.Errorf("could not get pods for node %s", nodeName)
 		}
 		r.Pods[nodeName] = pods
 
-		services, err := n.Services(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not get services for node %s: %v", nodeName, err)
+		if len(n.GetProto().GetServices()) > 0 {
+			services, ok := svcMap[nodeName]
+			if !ok || len(services) == 0 {
+				return nil, fmt.Errorf("could not get services for node %s", nodeName)
+			}
+			r.Services[nodeName] = services
 		}
-		r.Services[nodeName] = services
 	}
 
 	tList, err := m.topologyResources(ctx)

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -801,41 +801,41 @@ func (m *Manager) Resources(ctx context.Context) (*Resources, error) {
 		Topologies: map[string]*topologyv1.Topology{},
 	}
 
-	podList, err := m.kClient.CoreV1().Pods(m.topo.Name).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pods for topology %s: %w", m.topo.Name, err)
-	}
-	podMap := map[string][]*corev1.Pod{}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-		podMap[pod.Name] = append(podMap[pod.Name], pod)
-	}
-
-	serviceList, err := m.kClient.CoreV1().Services(m.topo.Name).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list services for topology %s: %w", m.topo.Name, err)
-	}
-	svcMap := map[string][]*corev1.Service{}
-	for i := range serviceList.Items {
-		svc := &serviceList.Items[i]
-		nodeName := strings.TrimPrefix(svc.Name, "service-")
-		svcMap[nodeName] = append(svcMap[nodeName], svc)
-	}
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
 
 	for nodeName, n := range m.nodes {
-		pods, ok := podMap[nodeName]
-		if !ok || len(pods) == 0 {
-			return nil, fmt.Errorf("could not get pods for node %s", nodeName)
-		}
-		r.Pods[nodeName] = pods
-
-		if len(n.GetProto().GetServices()) > 0 {
-			services, ok := svcMap[nodeName]
-			if !ok || len(services) == 0 {
-				return nil, fmt.Errorf("could not get services for node %s", nodeName)
+		wg.Add(1)
+		go func(name string, nd node.Node) {
+			defer wg.Done()
+			pods, err := nd.Pods(ctx)
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("could not get pods for node %s: %v", name, err)
+				}
+				mu.Unlock()
+				return
 			}
-			r.Services[nodeName] = services
-		}
+			services, err := nd.Services(ctx)
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("could not get services for node %s: %v", name, err)
+				}
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			r.Pods[name] = pods
+			r.Services[name] = services
+			mu.Unlock()
+		}(nodeName, n)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
 	}
 
 	tList, err := m.topologyResources(ctx)

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -807,9 +807,9 @@ func (m *Manager) Resources(ctx context.Context) (*Resources, error) {
 
 	for nodeName, n := range m.nodes {
 		wg.Add(1)
-		go func(name string, nd node.Node) {
+		go func(name string, nod node.Node) {
 			defer wg.Done()
-			pods, err := nd.Pods(ctx)
+			pods, err := nod.Pods(ctx)
 			if err != nil {
 				mu.Lock()
 				if firstErr == nil {
@@ -818,7 +818,7 @@ func (m *Manager) Resources(ctx context.Context) (*Resources, error) {
 				mu.Unlock()
 				return
 			}
-			services, err := nd.Services(ctx)
+			services, err := nod.Services(ctx)
 			if err != nil {
 				mu.Lock()
 				if firstErr == nil {

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/kr/pretty"
-	topologyclientv1 "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1"
-	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
 	"github.com/openconfig/gnmi/errlist"
 	"github.com/openconfig/kne/cluster/kind"
 	"github.com/openconfig/kne/events"
@@ -37,6 +35,8 @@ import (
 	cpb "github.com/openconfig/kne/proto/controller"
 	epb "github.com/openconfig/kne/proto/event"
 	tpb "github.com/openconfig/kne/proto/topo"
+	topologyclientv1 "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1"
+	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
 	"github.com/openconfig/kne/topo/node"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -419,11 +419,11 @@ func (m *Manager) Show(ctx context.Context) (*cpb.ShowTopologyResponse, error) {
 	var wg sync.WaitGroup
 	for _, n := range m.nodes {
 		wg.Add(1)
-		go func(nd node.Node) {
+		go func(nod node.Node) {
 			defer wg.Done()
-			phase, _ := nd.Status(ctx)
+			phase, _ := nod.Status(ctx)
 			mu.Lock()
-			stateMap.setNodeState(nd.Name(), phase)
+			stateMap.setNodeState(nod.Name(), phase)
 			mu.Unlock()
 		}(n)
 	}
@@ -749,19 +749,19 @@ func (m *Manager) checkNodeStatus(ctx context.Context, timeout time.Duration) er
 			}
 
 			wg.Add(1)
-			go func(name string, nd node.Node) {
+			go func(name string, nod node.Node) {
 				defer wg.Done()
-				phase, err := nd.Status(ctx)
+				phase, err := nod.Status(ctx)
 				mu.Lock()
 				defer mu.Unlock()
 				if err != nil || phase == node.StatusFailed {
 					if firstErr == nil {
-						firstErr = fmt.Errorf("Node %s: Status %s Reason %v", nd, phase, err)
+						firstErr = fmt.Errorf("Node %s: Status %s Reason %v", nod, phase, err)
 					}
 					return
 				}
 				if phase == node.StatusRunning {
-					log.Infof("Node %s: Status %s", nd, phase)
+					log.Infof("Node %s: Status %s", nod, phase)
 					processed[name] = true
 				} else {
 					foundAll = false

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -601,7 +601,7 @@ func TestCreate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: `Node "bad" (vendor: "1002", model: ""): Status FAILED`,
+		wantErr: `node "bad" (vendor: "1002", model: ""): status FAILED`,
 	}, {
 		desc: "failed to report metrics, create still passes",
 		opts: []Option{WithUsageReporting(true, "", "")},


### PR DESCRIPTION
KNE's K8s client was throttled to 5 QPS. At startup time, this is a huge source of delay. Similarly meshnet had the same default limit.

The delay was even worse because KNE was looking up pods & services as separate, individual calls. Using List() for these operations is a big speedup given the rate limiting.