### PR TITLE
build(cloudbuild): support regions in CI

### DIFF
--- a/cloudbuild/presubmit.yaml
+++ b/cloudbuild/presubmit.yaml
@@ -1,24 +1,28 @@
 steps:
   - id: kne_test
-    name: us-west1-docker.pkg.dev/$PROJECT_ID/utilities/remote-builder
+    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    entrypoint: bash
+    args: ["cloudbuild/remote-builder.sh"]
     waitFor: ["-"]
     env:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=kne-presubmit-kne-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 200GB --boot-disk-type pd-ssd
-      - ZONE=us-central1-a
+      - REGION=us-central1
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=source /tmp/workspace/cloudbuild/kne_test.sh 2>&1
   - id: vendors_test
-    name: us-west1-docker.pkg.dev/$PROJECT_ID/utilities/remote-builder
+    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    entrypoint: bash
+    args: ["cloudbuild/remote-builder.sh"]
     waitFor: ["-"]
     env:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=kne-presubmit-vendors-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-32 --boot-disk-size 200GB --boot-disk-type pd-ssd --enable-nested-virtualization
-      - ZONE=us-central1-a
+      - REGION=us-central1
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=source /tmp/workspace/cloudbuild/vendors_test.sh 2>&1
 

--- a/cloudbuild/presubmit.yaml
+++ b/cloudbuild/presubmit.yaml
@@ -1,3 +1,4 @@
+---
 steps:
   - id: kne_test
     name: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
@@ -8,7 +9,13 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=kne-presubmit-kne-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 200GB --boot-disk-type pd-ssd
+      - >-
+        INSTANCE_ARGS=--network cloudbuild-workers
+        --image-project gep-kne
+        --image-family kne
+        --machine-type e2-standard-4
+        --boot-disk-size 200GB
+        --boot-disk-type pd-ssd
       - REGION=us-central1
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=source /tmp/workspace/cloudbuild/kne_test.sh 2>&1
@@ -21,7 +28,14 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=kne-presubmit-vendors-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-32 --boot-disk-size 200GB --boot-disk-type pd-ssd --enable-nested-virtualization
+      - >-
+        INSTANCE_ARGS=--network cloudbuild-workers
+        --image-project gep-kne
+        --image-family kne
+        --machine-type n2-standard-32
+        --boot-disk-size 200GB
+        --boot-disk-type pd-ssd
+        --enable-nested-virtualization
       - REGION=us-central1
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=source /tmp/workspace/cloudbuild/vendors_test.sh 2>&1
@@ -30,4 +44,5 @@ timeout: 2700s
 
 options:
   pool:
-    name: "projects/kne-external/locations/us-central1/workerPools/kne-cloudbuild-pool"
+    name: >-
+      projects/kne-external/locations/us-central1/workerPools/kne-cloudbuild-pool

--- a/cloudbuild/remote-builder.sh
+++ b/cloudbuild/remote-builder.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -xe
+
+# Configurable parameters
+[ -z "$COMMAND" ] && echo "Need to set COMMAND" && exit 1;
+
+USERNAME=${USERNAME:-admin}
+REMOTE_WORKSPACE=${REMOTE_WORKSPACE:-/home/${USERNAME}/workspace/}
+INSTANCE_NAME=${INSTANCE_NAME:-builder-$(cat /proc/sys/kernel/random/uuid)}
+ZONE=${ZONE:-us-central1-f}
+INSTANCE_ARGS=${INSTANCE_ARGS:---preemptible}
+SSH_ARGS=${SSH_ARGS:-}
+GCLOUD=${GCLOUD:-gcloud}
+RETRIES=${RETRIES:-10}
+
+# Always delete instance after attempting build
+function cleanup {
+    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --quiet
+}
+
+# Run command on the instance via ssh
+function ssh {
+    ${GCLOUD} compute ssh ${SSH_ARGS} --ssh-key-file=${KEYNAME} \
+         ${USERNAME}@${INSTANCE_NAME} -- $1
+}
+
+${GCLOUD} config set compute/zone ${ZONE}
+
+KEYNAME=builder-key
+# TODO Need to be able to detect whether a ssh key was already created
+ssh-keygen -t rsa -N "" -f ${KEYNAME} -C ${USERNAME} || true
+chmod 400 ${KEYNAME}*
+
+cat > ssh-keys <<EOF
+${USERNAME}:$(cat ${KEYNAME}.pub)
+EOF
+
+${GCLOUD} compute instances create \
+       ${INSTANCE_ARGS} ${INSTANCE_NAME} \
+       --metadata block-project-ssh-keys=TRUE \
+       --metadata-from-file ssh-keys=ssh-keys
+
+trap cleanup EXIT
+
+RETRY_COUNT=1
+while [ "$(ssh 'printf pass')" != "pass" ]; do
+  echo "[Try $RETRY_COUNT of $RETRIES] Waiting for instance to start accepting SSH connections..."
+  if [ "$RETRY_COUNT" == "$RETRIES" ]; then
+    echo "Retry limit reached, giving up!"
+    exit 1
+  fi
+  sleep 10
+  RETRY_COUNT=$(($RETRY_COUNT+1))
+done
+
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
+       $(pwd) ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \
+       --ssh-key-file=${KEYNAME}
+
+ssh "${COMMAND}"
+
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
+       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}* $(pwd) \
+       --ssh-key-file=${KEYNAME}

--- a/cloudbuild/remote-builder.sh
+++ b/cloudbuild/remote-builder.sh
@@ -1,4 +1,17 @@
 #!/bin/bash -xe
+# Copyright 2017-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Configurable parameters
 [ -z "$COMMAND" ] && echo "Need to set COMMAND" && exit 1;
@@ -6,24 +19,27 @@
 USERNAME=${USERNAME:-admin}
 REMOTE_WORKSPACE=${REMOTE_WORKSPACE:-/home/${USERNAME}/workspace/}
 INSTANCE_NAME=${INSTANCE_NAME:-builder-$(cat /proc/sys/kernel/random/uuid)}
-ZONE=${ZONE:-us-central1-f}
+REGION=${REGION:-us-central1}
 INSTANCE_ARGS=${INSTANCE_ARGS:---preemptible}
 SSH_ARGS=${SSH_ARGS:-}
 GCLOUD=${GCLOUD:-gcloud}
 RETRIES=${RETRIES:-10}
 
+CREATED_ZONE=""
+
 # Always delete instance after attempting build
 function cleanup {
-    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --quiet
+  if [ -n "${CREATED_ZONE}" ]; then
+    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --zone=${CREATED_ZONE} --quiet || true
+  fi
 }
+trap cleanup EXIT
 
 # Run command on the instance via ssh
 function ssh {
-    ${GCLOUD} compute ssh ${SSH_ARGS} --ssh-key-file=${KEYNAME} \
-         ${USERNAME}@${INSTANCE_NAME} -- $1
+  ${GCLOUD} compute ssh ${SSH_ARGS} --zone=${CREATED_ZONE} --ssh-key-file=${KEYNAME} \
+       ${USERNAME}@${INSTANCE_NAME} -- "$1"
 }
-
-${GCLOUD} config set compute/zone ${ZONE}
 
 KEYNAME=builder-key
 # TODO Need to be able to detect whether a ssh key was already created
@@ -34,12 +50,56 @@ cat > ssh-keys <<EOF
 ${USERNAME}:$(cat ${KEYNAME}.pub)
 EOF
 
-${GCLOUD} compute instances create \
-       ${INSTANCE_ARGS} ${INSTANCE_NAME} \
-       --metadata block-project-ssh-keys=TRUE \
-       --metadata-from-file ssh-keys=ssh-keys
+# Determine candidate zones
+if [ -n "${ZONE}" ]; then
+  CANDIDATE_ZONES="${ZONE}"
+else
+  CANDIDATE_ZONES=$(${GCLOUD} compute zones list --filter="region:(${REGION}) AND status:UP" --format="value(name)" | shuf)
+fi
 
-trap cleanup EXIT
+if [ -z "${CANDIDATE_ZONES}" ]; then
+  echo "Error: No UP zones found for region '${REGION:-${ZONE}}'."
+  exit 1
+fi
+
+echo "Candidate zone evaluation order:"
+echo "${CANDIDATE_ZONES}"
+
+for z in ${CANDIDATE_ZONES}; do
+  echo "Attempting to create instance '${INSTANCE_NAME}' in zone '${z}'..."
+  set +e
+  CREATE_OUT=$(${GCLOUD} compute instances create \
+         ${INSTANCE_ARGS} ${INSTANCE_NAME} \
+         --zone="${z}" \
+         --metadata block-project-ssh-keys=TRUE \
+         --metadata-from-file ssh-keys=ssh-keys 2>&1)
+  CREATE_STATUS=$?
+  set -e
+
+  if [ ${CREATE_STATUS} -eq 0 ]; then
+    echo "Successfully created instance '${INSTANCE_NAME}' in zone '${z}'."
+    CREATED_ZONE="${z}"
+    break
+  fi
+
+  echo "Failed to create instance in zone '${z}':"
+  echo "${CREATE_OUT}"
+
+  # Check if failure is due to capacity stockout
+  if echo "${CREATE_OUT}" | grep -Eq "ZONE_RESOURCE_POOL_EXHAUSTED|state:STOCKOUT|does not have enough resources|resource pool exhausted"; then
+    echo "Stockout detected in zone '${z}'. Retrying next zone..."
+  else
+    echo "Non-stockout failure encountered in zone '${z}'. Aborting."
+    exit ${CREATE_STATUS}
+  fi
+done
+
+if [ -z "${CREATED_ZONE}" ]; then
+  echo "Error: All candidate zones exhausted due to stockouts for instance '${INSTANCE_NAME}'."
+  exit 1
+fi
+
+${GCLOUD} config set compute/zone ${CREATED_ZONE}
 
 RETRY_COUNT=1
 while [ "$(ssh 'printf pass')" != "pass" ]; do
@@ -52,12 +112,12 @@ while [ "$(ssh 'printf pass')" != "pass" ]; do
   RETRY_COUNT=$(($RETRY_COUNT+1))
 done
 
-${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
-       $(pwd) ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \
-       --ssh-key-file=${KEYNAME}
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
+       "$(pwd)" "${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}" \
+       --ssh-key-file="${KEYNAME}"
 
 ssh "${COMMAND}"
 
-${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
-       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}* $(pwd) \
-       --ssh-key-file=${KEYNAME}
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
+       "${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}"* "$(pwd)" \
+       --ssh-key-file="${KEYNAME}"

--- a/cloudbuild/remote-builder.sh
+++ b/cloudbuild/remote-builder.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Configurable parameters
-[ -z "$COMMAND" ] && echo "Need to set COMMAND" && exit 1;
+[ -z "$COMMAND" ] && echo "Need to set COMMAND" && exit 1
 
 USERNAME=${USERNAME:-admin}
 REMOTE_WORKSPACE=${REMOTE_WORKSPACE:-/home/${USERNAME}/workspace/}
@@ -28,96 +28,100 @@ RETRIES=${RETRIES:-10}
 CREATED_ZONE=""
 
 # Always delete instance after attempting build
-function cleanup {
-  if [ -n "${CREATED_ZONE}" ]; then
-    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --zone=${CREATED_ZONE} --quiet || true
-  fi
+cleanup() {
+	if [ -n "${CREATED_ZONE}" ]; then
+		"${GCLOUD}" compute instances delete "${INSTANCE_NAME}" --zone="${CREATED_ZONE}" --quiet || true
+	fi
 }
 trap cleanup EXIT
 
 # Run command on the instance via ssh
-function ssh {
-  ${GCLOUD} compute ssh ${SSH_ARGS} --zone=${CREATED_ZONE} --ssh-key-file=${KEYNAME} \
-       ${USERNAME}@${INSTANCE_NAME} -- "$1"
+ssh() {
+	# shellcheck disable=SC2086
+	"${GCLOUD}" compute ssh ${SSH_ARGS} --zone="${CREATED_ZONE}" --ssh-key-file="${KEYNAME}" \
+		"${USERNAME}"@"${INSTANCE_NAME}" -- "$1"
 }
 
 KEYNAME=builder-key
 # TODO Need to be able to detect whether a ssh key was already created
-ssh-keygen -t rsa -N "" -f ${KEYNAME} -C ${USERNAME} || true
-chmod 400 ${KEYNAME}*
+ssh-keygen -t rsa -N "" -f "${KEYNAME}" -C "${USERNAME}" || true
+chmod 400 "${KEYNAME}"*
 
-cat > ssh-keys <<EOF
-${USERNAME}:$(cat ${KEYNAME}.pub)
+cat >ssh-keys <<EOF
+${USERNAME}:$(cat "${KEYNAME}.pub")
 EOF
 
 # Determine candidate zones
 if [ -n "${ZONE}" ]; then
-  CANDIDATE_ZONES="${ZONE}"
+	CANDIDATE_ZONES="${ZONE}"
 else
-  CANDIDATE_ZONES=$(${GCLOUD} compute zones list --filter="region:(${REGION}) AND status:UP" --format="value(name)" | shuf)
+	CANDIDATE_ZONES=$("${GCLOUD}" compute zones list --filter="region:(${REGION}) AND status:UP" --format="value(name)" | shuf)
 fi
 
 if [ -z "${CANDIDATE_ZONES}" ]; then
-  echo "Error: No UP zones found for region '${REGION:-${ZONE}}'."
-  exit 1
+	echo "Error: No UP zones found for region '${REGION:-${ZONE}}'."
+	exit 1
 fi
 
 echo "Candidate zone evaluation order:"
 echo "${CANDIDATE_ZONES}"
 
 for z in ${CANDIDATE_ZONES}; do
-  echo "Attempting to create instance '${INSTANCE_NAME}' in zone '${z}'..."
-  set +e
-  CREATE_OUT=$(${GCLOUD} compute instances create \
-         ${INSTANCE_ARGS} ${INSTANCE_NAME} \
-         --zone="${z}" \
-         --metadata block-project-ssh-keys=TRUE \
-         --metadata-from-file ssh-keys=ssh-keys 2>&1)
-  CREATE_STATUS=$?
-  set -e
+	echo "Attempting to create instance '${INSTANCE_NAME}' in zone '${z}'..."
+	set +e
+	# shellcheck disable=SC2086
+	CREATE_OUT=$("${GCLOUD}" compute instances create \
+		${INSTANCE_ARGS} "${INSTANCE_NAME}" \
+		--zone="${z}" \
+		--metadata block-project-ssh-keys=TRUE \
+		--metadata-from-file ssh-keys=ssh-keys 2>&1)
+	CREATE_STATUS=$?
+	set -e
 
-  if [ ${CREATE_STATUS} -eq 0 ]; then
-    echo "Successfully created instance '${INSTANCE_NAME}' in zone '${z}'."
-    CREATED_ZONE="${z}"
-    break
-  fi
+	if [ ${CREATE_STATUS} -eq 0 ]; then
+		echo "Successfully created instance '${INSTANCE_NAME}' in zone '${z}'."
+		CREATED_ZONE="${z}"
+		break
+	fi
 
-  echo "Failed to create instance in zone '${z}':"
-  echo "${CREATE_OUT}"
+	echo "Failed to create instance in zone '${z}':"
+	echo "${CREATE_OUT}"
 
-  # Check if failure is due to capacity stockout
-  if echo "${CREATE_OUT}" | grep -Eq "ZONE_RESOURCE_POOL_EXHAUSTED|state:STOCKOUT|does not have enough resources|resource pool exhausted"; then
-    echo "Stockout detected in zone '${z}'. Retrying next zone..."
-  else
-    echo "Non-stockout failure encountered in zone '${z}'. Aborting."
-    exit ${CREATE_STATUS}
-  fi
+	# Check if failure is due to capacity stockout
+	if echo "${CREATE_OUT}" | grep -Eq "ZONE_RESOURCE_POOL_EXHAUSTED|state:STOCKOUT|does not have enough resources|resource pool exhausted"; then
+		echo "Stockout detected in zone '${z}'. Retrying next zone..."
+	else
+		echo "Non-stockout failure encountered in zone '${z}'. Aborting."
+		exit ${CREATE_STATUS}
+	fi
 done
 
 if [ -z "${CREATED_ZONE}" ]; then
-  echo "Error: All candidate zones exhausted due to stockouts for instance '${INSTANCE_NAME}'."
-  exit 1
+	echo "Error: All candidate zones exhausted due to stockouts for instance '${INSTANCE_NAME}'."
+	exit 1
 fi
 
-${GCLOUD} config set compute/zone ${CREATED_ZONE}
+"${GCLOUD}" config set compute/zone "${CREATED_ZONE}"
 
 RETRY_COUNT=1
 while [ "$(ssh 'printf pass')" != "pass" ]; do
-  echo "[Try $RETRY_COUNT of $RETRIES] Waiting for instance to start accepting SSH connections..."
-  if [ "$RETRY_COUNT" == "$RETRIES" ]; then
-    echo "Retry limit reached, giving up!"
-    exit 1
-  fi
-  sleep 10
-  RETRY_COUNT=$(($RETRY_COUNT+1))
+	echo "[Try $RETRY_COUNT of $RETRIES] Waiting for instance to start accepting SSH connections..."
+	if [ "$RETRY_COUNT" == "$RETRIES" ]; then
+		echo "Retry limit reached, giving up!"
+		exit 1
+	fi
+	sleep 10
+	RETRY_COUNT=$((RETRY_COUNT + 1))
 done
 
-${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
-       "$(pwd)" "${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}" \
-       --ssh-key-file="${KEYNAME}"
+# shellcheck disable=SC2086
+"${GCLOUD}" compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
+	"$(pwd)" "${USERNAME}"@"${INSTANCE_NAME}":"${REMOTE_WORKSPACE}" \
+	--ssh-key-file="${KEYNAME}"
 
 ssh "${COMMAND}"
 
-${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
-       "${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}"* "$(pwd)" \
-       --ssh-key-file="${KEYNAME}"
+# shellcheck disable=SC2086
+"${GCLOUD}" compute scp ${SSH_ARGS} --compress --recurse --zone="${CREATED_ZONE}" \
+	"${USERNAME}"@"${INSTANCE_NAME}":"${REMOTE_WORKSPACE}"* "$(pwd)" \
+	--ssh-key-file="${KEYNAME}"


### PR DESCRIPTION
We frequently see stockout errors from GCP when we run CI tasks while deploying to 'us-central1-a' zone.  This change brings the remote-builder.sh script into this repository and updates it to take a REGION instead of a ZONE as an arg. This should try launching VMs in different zones instead of being locked to one.