### PR TITLE
Shift to using dynamic.Interface for meshnet and lemming

### DIFF
--- a/topo/node/openconfig/openconfig.go
+++ b/topo/node/openconfig/openconfig.go
@@ -25,12 +25,15 @@ import (
 
 	tpb "github.com/openconfig/kne/proto/topo"
 	"github.com/openconfig/kne/topo/node"
-	"github.com/openconfig/lemming/operator/api/clientset"
 	lemmingv1 "github.com/openconfig/lemming/operator/api/lemming/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	log "k8s.io/klog/v2"
 )
@@ -155,8 +158,14 @@ var (
 	_ node.Resetter     = (*Node)(nil)
 )
 
-var clientFn = func(c *rest.Config) (clientset.Interface, error) {
-	return clientset.NewForConfig(c)
+var lemmingGVR = schema.GroupVersionResource{
+	Group:    "lemming.openconfig.net",
+	Version:  "v1alpha1",
+	Resource: "lemmings",
+}
+
+var clientFn = func(c *rest.Config) (dynamic.Interface, error) {
+	return dynamic.NewForConfig(c)
 }
 
 func (n *Node) Create(ctx context.Context) error {
@@ -229,7 +238,11 @@ func (n *Node) lemmingCreate(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %v", err)
 	}
-	if _, err := cs.LemmingV1alpha1().Lemmings(n.Namespace).Create(ctx, dut, metav1.CreateOptions{}); err != nil {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dut)
+	if err != nil {
+		return fmt.Errorf("failed to convert lemming to unstructured: %w", err)
+	}
+	if _, err := cs.Resource(lemmingGVR).Namespace(n.Namespace).Create(ctx, &unstructured.Unstructured{Object: u}, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create lemming: %v", err)
 	}
 	return nil
@@ -261,8 +274,12 @@ func (n *Node) lemmingStatus(ctx context.Context) (node.Status, error) {
 	if err != nil {
 		return node.StatusUnknown, err
 	}
-	got, err := cs.LemmingV1alpha1().Lemmings(n.Namespace).Get(ctx, n.Name(), metav1.GetOptions{})
+	unstruct, err := cs.Resource(lemmingGVR).Namespace(n.Namespace).Get(ctx, n.Name(), metav1.GetOptions{})
 	if err != nil {
+		return node.StatusUnknown, err
+	}
+	var got lemmingv1.Lemming
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstruct.Object, &got); err != nil {
 		return node.StatusUnknown, err
 	}
 	switch got.Status.Phase {
@@ -294,7 +311,7 @@ func (n *Node) lemmingDelete(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return cs.LemmingV1alpha1().Lemmings(n.Namespace).Delete(ctx, n.Name(), metav1.DeleteOptions{})
+	return cs.Resource(lemmingGVR).Namespace(n.Namespace).Delete(ctx, n.Name(), metav1.DeleteOptions{})
 }
 
 func (n *Node) ResetCfg(ctx context.Context) error {

--- a/topo/node/openconfig/openconfig.go
+++ b/topo/node/openconfig/openconfig.go
@@ -203,6 +203,10 @@ func (n *Node) lemmingCreate(ctx context.Context) error {
 	}
 
 	dut := &lemmingv1.Lemming{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: lemmingv1.GroupVersion.String(),
+			Kind:       "Lemming",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeSpec.Name,
 			Namespace: n.Namespace,

--- a/topo/node/openconfig/openconfig_test.go
+++ b/topo/node/openconfig/openconfig_test.go
@@ -20,18 +20,20 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openconfig/gnmi/errdiff"
 	tpb "github.com/openconfig/kne/proto/topo"
 	"github.com/openconfig/kne/topo/node"
-	"github.com/openconfig/lemming/operator/api/clientset"
-	"github.com/openconfig/lemming/operator/api/clientset/fake"
 	lemmingv1 "github.com/openconfig/lemming/operator/api/lemming/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -122,11 +124,12 @@ func TestCreate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			cs := fake.NewSimpleClientset()
+			s := runtime.NewScheme()
+			cs := fakedynamic.NewSimpleDynamicClient(s)
 			cs.PrependReactor("create", "lemmings", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 				return tt.createErr != nil, nil, tt.createErr
 			})
-			clientFn = func(c *rest.Config) (clientset.Interface, error) {
+			clientFn = func(c *rest.Config) (dynamic.Interface, error) {
 				return cs, tt.clientFnErr
 			}
 
@@ -137,11 +140,15 @@ func TestCreate(t *testing.T) {
 			if tt.wantErr != "" {
 				return
 			}
-			got, err := cs.LemmingV1alpha1().Lemmings("default").Get(context.Background(), "test", metav1.GetOptions{})
+			unstruct, err := cs.Resource(lemmingGVR).Namespace("default").Get(context.Background(), "test", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if d := cmp.Diff(tt.want, got); d != "" {
+			got := &lemmingv1.Lemming{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstruct.Object, got); err != nil {
+				t.Fatal(err)
+			}
+			if d := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); d != "" {
 				t.Errorf("unexpected diff (-want +got):\n%s", d)
 			}
 		})
@@ -187,15 +194,17 @@ func TestLemmingStatus(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			cs := fake.NewSimpleClientset()
+			s := runtime.NewScheme()
+			cs := fakedynamic.NewSimpleDynamicClient(s)
 			cs.PrependReactor("get", "lemmings", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, &lemmingv1.Lemming{
+				u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&lemmingv1.Lemming{
 					Status: lemmingv1.LemmingStatus{
 						Phase: tt.inPhase,
 					},
-				}, tt.getErr
+				})
+				return true, &unstructured.Unstructured{Object: u}, tt.getErr
 			})
-			clientFn = func(c *rest.Config) (clientset.Interface, error) {
+			clientFn = func(c *rest.Config) (dynamic.Interface, error) {
 				return cs, tt.clientFnErr
 			}
 			n := &Node{&node.Impl{Proto: &tpb.Node{}}}
@@ -259,11 +268,12 @@ func TestLemmingDelete(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			cs := fake.NewSimpleClientset()
+			s := runtime.NewScheme()
+			cs := fakedynamic.NewSimpleDynamicClient(s)
 			cs.PrependReactor("delete", "lemmings", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 				return true, nil, tt.deleteErr
 			})
-			clientFn = func(c *rest.Config) (clientset.Interface, error) {
+			clientFn = func(c *rest.Config) (dynamic.Interface, error) {
 				return cs, tt.clientFnErr
 			}
 			n := &Node{&node.Impl{Proto: &tpb.Node{}}}

--- a/topo/node/openconfig/openconfig_test.go
+++ b/topo/node/openconfig/openconfig_test.go
@@ -103,6 +103,10 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		want: &lemmingv1.Lemming{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: lemmingv1.GroupVersion.String(),
+				Kind:       "Lemming",
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",


### PR DESCRIPTION
This is consistent with what we do for vendor images. (Cisco, Juniper, Nokia, Arista.) It reduces the number of indirect dependencies we pick up on K8s API libraries, which simplifies life within Google's monorepo.

Functionally, it changes nothing.