### PR TITLE
replace more instances of clientset with dynamic client

### DIFF
--- a/cmd/topology/topology_test.go
+++ b/cmd/topology/topology_test.go
@@ -11,16 +11,17 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	tfake "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1/fake"
 	"github.com/openconfig/gnmi/errdiff"
 	cpb "github.com/openconfig/kne/proto/controller"
 	tpb "github.com/openconfig/kne/proto/topo"
+	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
 	"github.com/openconfig/kne/topo"
 	"github.com/openconfig/kne/topo/node"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/testing/protocmp"
+	dfake "k8s.io/client-go/dynamic/fake"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
@@ -220,14 +221,11 @@ func TestReset(t *testing.T) {
 
 	rCmd := New()
 	origOpts := opts
-	tf, err := tfake.NewSimpleClientset()
-	if err != nil {
-		t.Fatalf("cannot create fake topology clientset")
-	}
+	tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 	opts = []topo.Option{
 		topo.WithClusterConfig(&rest.Config{}),
 		topo.WithKubeClient(kfake.NewSimpleClientset()),
-		topo.WithTopoClient(tf),
+		topo.WithDynamicClient(tf),
 	}
 	defer func() {
 		opts = origOpts
@@ -614,14 +612,11 @@ func TestPush(t *testing.T) {
 
 	rCmd := New()
 	origOpts := opts
-	tf, err := tfake.NewSimpleClientset()
-	if err != nil {
-		t.Fatalf("cannot create fake topology clientset")
-	}
+	tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 	opts = []topo.Option{
 		topo.WithClusterConfig(&rest.Config{}),
 		topo.WithKubeClient(kfake.NewSimpleClientset()),
-		topo.WithTopoClient(tf),
+		topo.WithDynamicClient(tf),
 	}
 	defer func() {
 		opts = origOpts

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,6 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
-github.com/h-fam/errdiff v1.0.2 h1:rPsW4ob2fMOIulwTEoZXaaUIuud7XUudw5SLKTZj3Ss=
-github.com/h-fam/errdiff v1.0.2/go.mod h1:FOzgnHXSEE3rRvmGXgmiqWl+H3lwLywYm9CSXqXrSTg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/topo/node/openconfig/openconfig.go
+++ b/topo/node/openconfig/openconfig.go
@@ -260,7 +260,7 @@ func (n *Node) Status(ctx context.Context) (node.Status, error) {
 	case modelLemming:
 		return n.lemmingStatus(ctx)
 	default:
-		return node.StatusUnknown, fmt.Errorf("invalid model specified.")
+		return node.StatusUnknown, fmt.Errorf("invalid model specified")
 	}
 }
 

--- a/topo/sonic_topo_test.go
+++ b/topo/sonic_topo_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	tfake "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1/fake"
 	tpb "github.com/openconfig/kne/proto/topo"
+	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
 	"github.com/openconfig/kne/topo"
 	_ "github.com/openconfig/kne/topo/node/sonic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	dfake "k8s.io/client-go/dynamic/fake"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	rest "k8s.io/client-go/rest"
 	ktest "k8s.io/client-go/testing"
@@ -20,10 +21,7 @@ import (
 func TestCreateSonicNode(t *testing.T) {
 	ctx := context.Background()
 
-	tf, err := tfake.NewSimpleClientset()
-	if err != nil {
-		t.Fatalf("cannot create fake topology clientset: %v", err)
-	}
+	tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 
 	kf := kfake.NewSimpleClientset()
 	kf.PrependReactor("get", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
@@ -54,7 +52,7 @@ func TestCreateSonicNode(t *testing.T) {
 	opts := []topo.Option{
 		topo.WithClusterConfig(&rest.Config{}),
 		topo.WithKubeClient(kf),
-		topo.WithTopoClient(tf),
+		topo.WithDynamicClient(tf),
 	}
 
 	m, err := topo.New(spec, opts...)

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -35,7 +35,6 @@ import (
 	cpb "github.com/openconfig/kne/proto/controller"
 	epb "github.com/openconfig/kne/proto/event"
 	tpb "github.com/openconfig/kne/proto/topo"
-	topologyclientv1 "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1"
 	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
 	"github.com/openconfig/kne/topo/node"
 	"google.golang.org/grpc/codes"
@@ -44,7 +43,11 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -76,6 +79,12 @@ var (
 
 	// Stubs for testing.
 	kindClusterIsKind = kind.ClusterIsKind
+
+	meshnetGVR = schema.GroupVersionResource{
+		Group:    topologyv1.GroupName,
+		Version:  topologyv1.GroupVersion,
+		Resource: "topologies",
+	}
 )
 
 // Manager is a topology manager for a cluster instance.
@@ -85,7 +94,7 @@ type Manager struct {
 	nodes          map[string]node.Node
 	kubecfg        string
 	kClient        kubernetes.Interface
-	tClient        topologyclientv1.Interface
+	dClient        dynamic.Interface
 	rCfg           *rest.Config
 	basePath       string
 	skipDeleteWait bool
@@ -118,9 +127,9 @@ func WithKubeClient(c kubernetes.Interface) Option {
 	}
 }
 
-func WithTopoClient(c topologyclientv1.Interface) Option {
+func WithDynamicClient(c dynamic.Interface) Option {
 	return func(m *Manager) {
-		m.tClient = c
+		m.dClient = c
 	}
 }
 
@@ -199,12 +208,12 @@ func New(topo *tpb.Topology, opts ...Option) (*Manager, error) {
 		}
 		m.kClient = kClient
 	}
-	if m.tClient == nil {
-		tClient, err := topologyclientv1.NewForConfig(m.rCfg)
+	if m.dClient == nil {
+		dClient, err := dynamic.NewForConfig(m.rCfg)
 		if err != nil {
 			return nil, err
 		}
-		m.tClient = tClient
+		m.dClient = dClient
 	}
 	if err := m.load(); err != nil {
 		return nil, fmt.Errorf("failed to load topology: %w", err)
@@ -435,7 +444,7 @@ func (m *Manager) Show(ctx context.Context) (*cpb.ShowTopologyResponse, error) {
 }
 
 func (m *Manager) Watch(ctx context.Context) error {
-	watcher, err := m.tClient.Topology(m.topo.Name).Watch(ctx, metav1.ListOptions{})
+	watcher, err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -700,7 +709,20 @@ func (m *Manager) createMeshnetTopologies(ctx context.Context) error {
 		go func(topo *topologyv1.Topology) {
 			defer wg.Done()
 			log.Infof("Creating topology for meshnet node %s", topo.Name)
-			sT, err := m.tClient.Topology(m.topo.Name).Create(ctx, topo, metav1.CreateOptions{})
+			topo.TypeMeta = metav1.TypeMeta{
+				Kind:       "Topology",
+				APIVersion: topologyv1.SchemeGroupVersion.String(),
+			}
+			obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(topo)
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("could not convert topology for meshnet node %s to unstructured: %w", topo.Name, err)
+				}
+				mu.Unlock()
+				return
+			}
+			sT, err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).Create(ctx, &unstructured.Unstructured{Object: obj}, metav1.CreateOptions{})
 			if err != nil {
 				mu.Lock()
 				if firstErr == nil {
@@ -724,7 +746,7 @@ func (m *Manager) deleteMeshnetTopologies(ctx context.Context) error {
 	}
 	var errs errlist.List
 	for _, n := range nodes {
-		if err := m.tClient.Topology(m.topo.Name).Delete(ctx, n.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+		if err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).Delete(ctx, n.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
 			errs.Add(fmt.Errorf("failed to delete meshnet node %q: %w", n.ObjectMeta.Name, err))
 		}
 	}
@@ -851,14 +873,18 @@ func (m *Manager) Resources(ctx context.Context) (*Resources, error) {
 
 // topologyResources gets the topology CRDs for the cluster.
 func (m *Manager) topologyResources(ctx context.Context) ([]*topologyv1.Topology, error) {
-	topology, err := m.tClient.Topology(m.topo.Name).List(ctx, metav1.ListOptions{})
+	unstructList, err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get topology CRDs: %v", err)
 	}
 
-	items := make([]*topologyv1.Topology, len(topology.Items))
-	for i := range items {
-		items[i] = &topology.Items[i]
+	items := make([]*topologyv1.Topology, len(unstructList.Items))
+	for i := range unstructList.Items {
+		item := &topologyv1.Topology{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructList.Items[i].UnstructuredContent(), item); err != nil {
+			return nil, fmt.Errorf("failed to decode topology CRD: %w", err)
+		}
+		items[i] = item
 	}
 
 	return items, nil

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -556,7 +556,7 @@ func setLinkPeer(nodeName string, podName string, link *topologyv1.Link, peerSpe
 		for _, peerLink := range peerSpec.Spec.Links {
 			// make sure self ifc and peer ifc belong to same link (and hence UID) but are not the same interfaces
 			if peerLink.UID == link.UID && !(nodeName == link.PeerPod && peerLink.LocalIntf == link.LocalIntf) {
-				link.PeerPod = peerSpec.ObjectMeta.Name
+				link.PeerPod = peerSpec.Name
 				link.PeerIntf = peerLink.LocalIntf
 				return nil
 			}
@@ -593,7 +593,7 @@ func (m *Manager) topologySpecs(ctx context.Context) ([]*topologyv1.Topology, er
 					return nil, fmt.Errorf("specs do not exist for node %s", link.PeerPod)
 				}
 
-				if err := setLinkPeer(nodeName, spec.ObjectMeta.Name, link, peerSpecs); err != nil {
+				if err := setLinkPeer(nodeName, spec.Name, link, peerSpecs); err != nil {
 					return nil, err
 				}
 			}
@@ -746,8 +746,8 @@ func (m *Manager) deleteMeshnetTopologies(ctx context.Context) error {
 	}
 	var errs errlist.List
 	for _, n := range nodes {
-		if err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).Delete(ctx, n.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
-			errs.Add(fmt.Errorf("failed to delete meshnet node %q: %w", n.ObjectMeta.Name, err))
+		if err := m.dClient.Resource(meshnetGVR).Namespace(m.topo.Name).Delete(ctx, n.Name, metav1.DeleteOptions{}); err != nil {
+			errs.Add(fmt.Errorf("failed to delete meshnet node %q: %w", n.Name, err))
 		}
 	}
 	return errs.Err()

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	tfake "github.com/openconfig/kne/third_party/meshnet/api/clientset/v1beta1/fake"
 	topologyv1 "github.com/openconfig/kne/third_party/meshnet/api/types/v1beta1"
+	dfake "k8s.io/client-go/dynamic/fake"
 	"github.com/openconfig/gnmi/errdiff"
 	cpb "github.com/openconfig/kne/proto/controller"
 	epb "github.com/openconfig/kne/proto/event"
@@ -161,14 +161,11 @@ func (nc *notCertable) GetProto() *tpb.Node {
 func TestNew(t *testing.T) {
 	node.Vendor(tpb.Vendor(1001), NewConfigurable)
 	node.Vendor(tpb.Vendor(1006), NewLoopbackable)
-	tf, err := tfake.NewSimpleClientset()
-	if err != nil {
-		t.Fatalf("cannot create fake topology clientset: %v", err)
-	}
+	tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 	opts := []Option{
 		WithClusterConfig(&rest.Config{}),
 		WithKubeClient(kfake.NewSimpleClientset()),
-		WithTopoClient(tf),
+		WithDynamicClient(tf),
 	}
 	tests := []struct {
 		desc      string
@@ -661,10 +658,7 @@ func TestCreate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			tf, err := tfake.NewSimpleClientset()
-			if err != nil {
-				t.Fatalf("cannot create fake topology clientset: %v", err)
-			}
+			tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 			kf := kfake.NewSimpleClientset()
 			kf.PrependReactor("get", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
 				gAction, ok := action.(ktest.GetAction)
@@ -687,7 +681,7 @@ func TestCreate(t *testing.T) {
 			opts := []Option{
 				WithClusterConfig(&rest.Config{}),
 				WithKubeClient(kf),
-				WithTopoClient(tf),
+				WithDynamicClient(tf),
 			}
 			opts = append(opts, tt.opts...)
 			m, err := New(tt.topo, opts...)
@@ -1004,10 +998,7 @@ func TestDelete(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			tf, err := tfake.NewSimpleClientset()
-			if err != nil {
-				t.Fatalf("cannot create fake topology clientset: %v", err)
-			}
+			tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 			kf := kfake.NewSimpleClientset(tt.k8sObjects...)
 			kf.PrependWatchReactor("*", func(action ktest.Action) (bool, watch.Interface, error) {
 				f := &fakeWatch{
@@ -1028,7 +1019,7 @@ func TestDelete(t *testing.T) {
 			opts := []Option{
 				WithClusterConfig(&rest.Config{}),
 				WithKubeClient(kf),
-				WithTopoClient(tf),
+				WithDynamicClient(tf),
 				WithSkipDeleteWait(tt.skipWait),
 			}
 			m, err := New(tt.topo, opts...)
@@ -1566,14 +1557,11 @@ func TestShow(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			tf, err := tfake.NewSimpleClientset()
-			if err != nil {
-				t.Fatalf("cannot create fake topology clientset: %v", err)
-			}
+			tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme)
 			opts := []Option{
 				WithClusterConfig(&rest.Config{}),
 				WithKubeClient(kfake.NewSimpleClientset(tt.k8sObjects...)),
-				WithTopoClient(tf),
+				WithDynamicClient(tf),
 			}
 			tTopo := proto.Clone(topo).(*tpb.Topology)
 			m, err := New(tTopo, opts...)
@@ -1762,14 +1750,11 @@ func TestResources(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			tf, err := tfake.NewSimpleClientset(tt.topoObjects...)
-			if err != nil {
-				t.Fatalf("cannot create fake topology clientset: %v", err)
-			}
+			tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme, tt.topoObjects...)
 			opts := []Option{
 				WithClusterConfig(&rest.Config{}),
 				WithKubeClient(kfake.NewSimpleClientset(tt.k8sObjects...)),
-				WithTopoClient(tf),
+				WithDynamicClient(tf),
 			}
 			tTopo := proto.Clone(topo).(*tpb.Topology)
 			m, err := New(tTopo, opts...)
@@ -2132,16 +2117,13 @@ func TestOptions(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	tf, err := tfake.NewSimpleClientset(&topologyv1.Topology{
+	tf := dfake.NewSimpleDynamicClient(topologyv1.Scheme, &topologyv1.Topology{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
 	})
-	if err != nil {
-		t.Fatalf("cannot create fake topology clientset: %v", err)
-	}
 	m := &Manager{
-		tClient: tf,
+		dClient: tf,
 		topo: &tpb.Topology{
 			Name: "test",
 		},


### PR DESCRIPTION
Shift to using dynamic.Interface for meshnet and lemming. I seem to have missed some instances of this in my prior PR. Now I've had the LLM check for complete coverage.

This is consistent with what we do for vendor images. (Cisco, Juniper, Nokia, Arista.) It reduces the number of indirect dependencies we pick up on K8s API libraries, which simplifies life within Google's monorepo.

Functionally, it changes nothing.