### PR TITLE
    This PR improves error handling, certificate idempotency, and command response validation for JunOS / cPTX nodes in KNE. 

### DIFF
--- a/topo/node/juniper/juniper.go
+++ b/topo/node/juniper/juniper.go
@@ -225,6 +225,12 @@ func (n *Node) GRPCConfig() []string {
 	}
 }
 
+var junosErrorRegex = regexp.MustCompile(`(?im)(\berror:|\bcommit error\b|\bsyntax error\b)`)
+
+func isJunosError(result string) bool {
+	return junosErrorRegex.MatchString(result)
+}
+
 // Waits and retries until CLI config mode is up and config is applied
 func (n *Node) waitConfigInfraReadyAndPushConfigs(configs []string) error {
 	log.Infof("Waiting for config to be pushed (timeout: %v) node %s", configModeTimeout, n.Name())
@@ -246,8 +252,8 @@ func (n *Node) waitConfigInfraReadyAndPushConfigs(configs []string) error {
 					log.Infof("Config mode ready. Config commit done. Node %s", n.Name())
 					return nil
 				}
-				if strings.Contains(resp.Result, "error:") {
-					log.Infof("Config mode not ready. Retrying in %v. Node %s Response %s", certGenRetrySleep, n.Name(), multiresp.JoinedResult())
+				if isJunosError(resp.Result) {
+					log.Infof("Config mode not ready. Retrying in %v. Node %s Response %s", configModeRetrySleep, n.Name(), multiresp.JoinedResult())
 				}
 			}
 		}
@@ -281,17 +287,37 @@ func (n *Node) waitCertInfraReadyAndPushCert() error {
 		if err != nil {
 			return fmt.Errorf("failed sending generate-self-signed commands: %v", err)
 		}
+		if len(multiresp.Responses) < len(commands) {
+			log.Infof("Incomplete response count from device. Retrying in %v. Node %s", certGenRetrySleep, n.Name())
+			time.Sleep(certGenRetrySleep)
+			continue
+		}
+		hasError := false
 		for _, resp := range multiresp.Responses {
 			if resp.Failed != nil {
 				return resp.Failed
 			}
-			if strings.Contains(resp.Result, "successfully") {
-				log.Infof("Cert Infra ready. Configured Certs. Node %s, Response %s", n.Name(), multiresp.JoinedResult())
-				return nil
-			}
-			if strings.Contains(resp.Result, "error:") {
+			if isJunosError(resp.Result) && !strings.Contains(strings.ToLower(resp.Result), "already exists") {
+				hasError = true
 				log.Infof("Cert infra isn't ready. Retrying in %v. Node %s Response %s", certGenRetrySleep, n.Name(), multiresp.JoinedResult())
+				break
 			}
+		}
+
+		// Dynamically locate the response for the generate-self-signed command
+		var certGenResult string
+		for i, cmd := range commands {
+			if strings.Contains(cmd, "generate-self-signed") && i < len(multiresp.Responses) {
+				certGenResult = multiresp.Responses[i].Result
+				break
+			}
+		}
+
+		certGenSuccess := strings.Contains(strings.ToLower(certGenResult), "successfully") || strings.Contains(strings.ToLower(certGenResult), "already exists")
+
+		if !hasError && certGenSuccess {
+			log.Infof("Cert Infra ready. Configured Certs. Node %s, Response %s", n.Name(), multiresp.JoinedResult())
+			return nil
 		}
 		time.Sleep(certGenRetrySleep)
 	}

--- a/topo/node/juniper/juniper_test.go
+++ b/topo/node/juniper/juniper_test.go
@@ -68,6 +68,31 @@ func removeCommentsFromConfig(t *testing.T, r io.Reader) io.Reader {
 	return &buf
 }
 
+func TestIsJunosError(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"error: Command aborted as key pair already exists", true},
+		{"[edit]\nerror: Schema was updated in background, failing the commit", true},
+		{"root@ncptx# commit\nerror: Commit failed: Schema mismatch/updated.", true},
+		{"commit error", true},
+		{"syntax error", true},
+		{"ERROR: fatal error occurred", true},
+		{"set interfaces et-0/0/0 description \"ignore-error\"", false},
+		{"domain-name error.com", false},
+		{"0 errors found in commit check", false},
+		{"Self-signed certificate generated and loaded successfully", false},
+	}
+
+	for _, tt := range tests {
+		got := isJunosError(tt.input)
+		if got != tt.want {
+			t.Errorf("isJunosError(%q) = %v; want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestGenerateSelfSigned(t *testing.T) {
 	ki := fake.NewSimpleClientset(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -146,11 +171,18 @@ func TestGenerateSelfSigned(t *testing.T) {
 			testFile: "testdata/generate_certificate_success",
 		},
 		{
-			// device returns "Error: something bad happened" -- we expect to fail
-			desc:     "failure",
-			wantErr:  true,
+			// device returns "error: Command aborted as key pair/certificate already exists" -- expected to succeed idempotently
+			desc:     "success cert already exists",
+			wantErr:  false,
 			ni:       ni,
 			testFile: "testdata/generate_certificate_failure",
+		},
+		{
+			// key pair generation succeeds with 'successfully' but self-signed cert generation fails
+			desc:     "failure key success cert failure",
+			wantErr:  true,
+			ni:       ni,
+			testFile: "testdata/generate_certificate_key_success_cert_failure",
 		},
 		{
 			// device returns config mode error but we eventually recover
@@ -973,10 +1005,10 @@ func TestCreate(t *testing.T) {
 				Namespace:  "test",
 				KubeClient: ki,
 				Proto: &tpb.Node{
-					Name:       "ncptx",
-					Model:      "ncptx",
-					Vendor:     tpb.Vendor_JUNIPER,
-					Config:     cfg,
+					Name:   "ncptx",
+					Model:  "ncptx",
+					Vendor: tpb.Vendor_JUNIPER,
+					Config: cfg,
 					Interfaces: map[string]*tpb.Interface{
 						"eth1": {Name: "et-0/0/0:0"},
 					},

--- a/topo/node/juniper/testdata/generate_certificate_key_success_cert_failure
+++ b/topo/node/juniper/testdata/generate_certificate_key_success_cert_failure
@@ -1,0 +1,21 @@
+root@cptx2>
+
+root@cptx2> set cli screen-width 511
+Screen width set to 511
+
+root@cptx2> set cli screen-length 0
+Screen length set to 0
+
+root@cptx2> set cli complete-on-space off
+Disabling complete-on-space
+
+root@cptx2> request security pki generate-key-pair certificate-id grpc-server-cert
+Generated key pair grpc-server-cert successfully
+
+root@cptx2> request security pki local-certificate generate-self-signed certificate-id grpc-server-cert subject CN=abc domain-name google.com ip-address 1.2.3.4 email example@google.com
+error: PKI service is not ready. Retry later.
+
+root@cptx2>
+root@cptx2>exit
+
+root@cptx2>


### PR DESCRIPTION
 1. **Premature Success Validation**: When pushing self-signed certificates via CLI, `waitCertInfraReadyAndPushCert` sent multiple commands  
  (`generate-key-pair` and `generate-self-signed`). The loop previously evaluated `strings.Contains(resp.Result, "successfully")` on any        
  response in the batch. Because key pair generation finishes first with `"Generated key pair ... successfully"`, the method would return `nil` 
  prematurely even if the second command (`generate-self-signed`) failed or was not yet processed.
    2. **Failure on Node Restarts / Reuse**: When a pod/node restarted or was reused with an existing certificate, JunOS returned `error:       
  Command aborted as key pair/certificate already exists`. The previous logic treated this as an error, causing a retry loop until the 15-minute
  timeout failed the deployment.
    3. **Regex Accuracy**: Error checking relied on a simple substring match on `"error:"`. This was vulnerable to false negatives on multi-line
  error blocks or non-standard error phrasings (`commit error`, `syntax error`), as well as potential false positives on configuration strings  
  (e.g., interface descriptions or domain names).
    4. **Log Mismatch**: In `waitConfigInfraReadyAndPushConfigs`, the retry log incorrectly reported `certGenRetrySleep` instead of             
  `configModeRetrySleep`.
  
    ## Changes Made
    - **Idempotent Cert Handling**: Updated `waitCertInfraReadyAndPushCert` to recognize `"already exists"` outputs as a successful / idempotent
  state rather than an error condition.
    - **Dynamic Response Verification**: Dynamically locate the response corresponding specifically to the `generate-self-signed` command,      
  verifying that no non-idempotent errors occurred across any command (`!hasError`) and that certificate generation explicitly succeeded        
  (`certGenSuccess`).
    - **Incomplete Batch Guard**: Added a response count check (`len(multiresp.Responses) < len(commands)`) to avoid evaluating truncated       
  command batches.
    - **Robust Error Regex**: Implemented `isJunosError` with regex `(?im)(\berror:|\bcommit error\b|\bsyntax error\b)` to handle multi-line and
  case-insensitive JunOS CLI errors without false positives.
    - **Log Correction**: Fixed the sleep duration reported in the retry log inside `waitConfigInfraReadyAndPushConfigs`.
    - **Unit Tests & Fixtures**:
      - Added `TestIsJunosError` covering edge cases and false-positive prevention.
      - Updated `TestGenerateSelfSigned` to verify idempotency on existing certificates.
      - Added `testdata/generate_certificate_key_success_cert_failure` test fixture to prevent regressions where key-generation success masks   
  cert-generation failure.
  
    ## Testing Done
    - Ran package unit tests: `go test -v ./topo/node/juniper/...` (100% PASS)
    - Ran all node vendor tests: `go test ./topo/node/...` (100% PASS)
    - Verified formatting with `gofmt` and static checks with `go vet`.
