### PR TITLE
Migrate to lemming operator v0.2.9

### DIFF
--- a/load/testdata/manifests/controllers/lemming/manifest.yaml
+++ b/load/testdata/manifests/controllers/lemming/manifest.yaml
@@ -537,7 +537,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: us-west1-docker.pkg.dev/openconfig-lemming/release/operator:v0.2.8
+          image: us-west1-docker.pkg.dev/openconfig-lemming/release/operator:v0.2.9
           livenessProbe:
             httpGet:
               path: /healthz

--- a/manifests/controllers/lemming/manifest.yaml
+++ b/manifests/controllers/lemming/manifest.yaml
@@ -559,7 +559,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: us-west1-docker.pkg.dev/openconfig-lemming/release/operator:v0.2.8
+          image: us-west1-docker.pkg.dev/openconfig-lemming/release/operator:v0.2.9
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
This picks up key changes:
* Fix controller workqueue rate limits (faster lemming startup)
* Don't allocate nodeports for lemming k8s services (like other KNE-created services)